### PR TITLE
Let orun handle ocaml programs that use escape sequences in stderr

### DIFF
--- a/orun/dune
+++ b/orun/dune
@@ -6,4 +6,4 @@
 (executable
  (name orun)
  (public_name orun)
- (libraries cmdliner yojson unix wait4))
+ (libraries str cmdliner yojson unix wait4))


### PR DESCRIPTION

Let orun handle ocaml programs that use escape sequences in stderr (e.g. compilers)