### PR TITLE
Sampling coverage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
 - name: 4.07.1.bench
   image: ocaml/opam2:4.07
   commands:
-  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4
+  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
@@ -17,7 +17,7 @@ steps:
 - name: 4.07.1.parallelbench
   image: ocaml/opam2:4.07
   commands:
-  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4
+  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
@@ -26,7 +26,7 @@ steps:
 - name: 4.06.1+multicore.multibench
   image: ocaml/opam2:4.07
   commands:
-  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4
+  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp
 	{ url="$$(cat ocaml-versions/$*.comp)"; echo "url { src: \"$$url\" }"; echo "setenv: [ [ ORUN_CONFIG_ocaml_url = \"$$url\" ] ]"; } \
 	  >> dependencies/packages/ocaml-base-compiler/ocaml-base-compiler.$*/opam
 	opam update
-	opam switch create --yes $* ocaml-base-compiler.$*
+	opam switch create --keep-build-dir --yes $* ocaml-base-compiler.$*
 	opam pin add -n --yes --switch $* orun orun/
 
 
@@ -60,7 +60,7 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp
 .FORCE:
 ocaml-versions/%.bench: ocaml-versions/%.comp _opam/% .FORCE
 	@opam update
-	@opam install --switch=$* --best-effort --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
+	@opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 	@{ echo '(lang dune 1.0)'; \
 	   for i in `seq 1 $(ITER)`; do \
 	     echo "(context (opam (switch $*) (name $*_$$i)))"; \

--- a/orun/common.ml
+++ b/orun/common.ml
@@ -1,0 +1,37 @@
+type source_line =
+  { filename: string option
+  ; function_name: string option
+  ; line: int
+  ; offset: int }
+
+type sample =
+  { current: source_line
+  ; call_stack: source_line list
+  ; timestamp: int
+  ; thread_id: int
+  ; cpu: int
+  ; id: int }
+
+type counts = {mutable self_time: int; mutable total_time: int}
+
+type aggregate_result = (source_line, counts) Hashtbl.t
+
+type compressed_sample =
+  {stack: int list; timestamp: int; thread_id: int; cpu: int; id: int}
+
+let rec take l n =
+  match (l, n) with
+  | [], _ ->
+      []
+  | _, 0 ->
+      []
+  | h :: tl, _ ->
+      h :: take tl (n - 1)
+
+let get_or d o = match o with None -> d | Some x -> x
+
+let invert_hashtbl h =
+  Hashtbl.fold
+    (fun k v c -> Hashtbl.add c v k ; c)
+    h
+    (Hashtbl.create (Hashtbl.length h))

--- a/orun/config/detect_os.ml
+++ b/orun/config/detect_os.ml
@@ -1,0 +1,18 @@
+module C = Configurator.V1
+
+let is_linux () = 
+  let ic = Unix.open_process_in "uname -s" in
+  let uname = input_line ic in
+  let () = close_in ic in
+  match uname with
+  | "Linux" -> true
+  | _ -> false
+
+let () =
+C.main ~name:"detect_os" (fun c ->
+let c_linker_flags = if is_linux () then
+    ["-ldw"]
+    else
+    []
+in
+C.Flags.write_sexp "profiler_library_flags.sexp" c_linker_flags)

--- a/orun/config/dune
+++ b/orun/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name detect_os)
+ (libraries dune.configurator))

--- a/orun/dune
+++ b/orun/dune
@@ -3,7 +3,18 @@
  (c_names wait4)
  (modules ))
 
+(library
+ (name profiler)
+ (c_names profiler)
+ (c_library_flags (:include profiler_library_flags.sexp))
+ (modules ))
+
 (executable
  (name orun)
  (public_name orun)
- (libraries str cmdliner yojson unix wait4))
+ (libraries str cmdliner yojson unix wait4 profiler))
+
+(rule
+ (targets profiler_library_flags.sexp)
+ (deps    (:detect_os config/detect_os.exe))
+ (action  (run %{detect_os})))

--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -1,42 +1,54 @@
-type wait4_result = {
-  status: Unix.process_status;
-  user_secs: float;
-  sys_secs: float;
-  maxrss_kB: int
-}
+type wait4_result =
+  { status: Unix.process_status
+  ; user_secs: float
+  ; sys_secs: float
+  ; maxrss_kB: int }
+
 external wait4 : int -> wait4_result = "ml_wait4"
 
 let escape_re = Str.regexp "\\(\027\\[[0-9:;]*m\\)*"
 
-let clean_escape_sequences line =
-  Str.global_replace escape_re "" line
+let clean_escape_sequences line = Str.global_replace escape_re "" line
 
 let escape_sequences_only line =
   let _ = Str.search_forward escape_re line 0 in
   Str.matched_string line
 
 let quotes_needed = function
-  | 'a'..'z' | 'A'..'Z' | '0'..'9' | '/' | '_' | '.' | ',' | '-' | '+' | ':' -> false
-  | _ -> true
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '0' .. '9'
+  | '/'
+  | '_'
+  | '.'
+  | ','
+  | '-'
+  | '+'
+  | ':' ->
+      false
+  | _ ->
+      true
 
 let quote s =
   match String.iter (fun ch -> if quotes_needed ch then raise Exit) s with
-  | () -> s
-  | exception Exit -> Filename.quote s
+  | () ->
+      s
+  | exception Exit ->
+      Filename.quote s
 
 let quote_cmd cmdline = String.concat " " (List.map quote cmdline)
 
 let starts_with s line =
-  String.length line >= String.length s &&
-    s = String.sub line 0 (String.length s)
+  String.length line >= String.length s
+  && s = String.sub line 0 (String.length s)
 
 let break ch s =
   let open String in
   let i = index s ch in
-  trim (sub s 0 i), trim (sub s (i+1) (String.length s - (i+1)))
+  (trim (sub s 0 i), trim (sub s (i + 1) (String.length s - (i + 1))))
 
 let chop_prefix pfx s =
-  assert (starts_with pfx s);
+  assert (starts_with pfx s) ;
   String.sub s (String.length pfx) (String.length s - String.length pfx)
 
 let get_ocaml_config () =
@@ -82,103 +94,161 @@ let get_ocaml_config () =
     | "ocamlopt_cflags"
     | "ocamlopt_cppflags"
     | "bytecomp_c_compiler"
-    | "native_c_compiler"
-      -> true
-    | _ -> false in
+    | "native_c_compiler" ->
+        true
+    | _ ->
+        false
+  in
   let default_val = function
-    | "model" -> Some "default"
-    | "flambda" -> Some "false"
-    | "spacetime" -> Some "false"
-    | "flat_float_array" -> Some "true"
-    | "afl_instrument" -> Some "false"
-    | "windows_unicode" -> Some "false"
-    | "with_frame_pointers" -> Some "false"
-    | _ -> None in
+    | "model" ->
+        Some "default"
+    | "flambda" ->
+        Some "false"
+    | "spacetime" ->
+        Some "false"
+    | "flat_float_array" ->
+        Some "true"
+    | "afl_instrument" ->
+        Some "false"
+    | "windows_unicode" ->
+        Some "false"
+    | "with_frame_pointers" ->
+        Some "false"
+    | _ ->
+        None
+  in
   let rec go () =
     match input_line ic with
-    | exception End_of_file -> []
+    | exception End_of_file ->
+        []
     | s ->
-       let key, value = break ':' s in
-       if boring key || default_val key = Some value then go ()
-       else (key, `String value) :: go () in
+        let key, value = break ':' s in
+        if boring key || default_val key = Some value then go ()
+        else (key, `String value) :: go ()
+  in
   `Assoc (go ())
 
 let gc_stats stderr_file =
   let ic = open_in stderr_file in
   let rec go found_stats =
-    match found_stats, input_line ic with
-    | exception End_of_file -> close_in ic; []
-    | false, line when not (starts_with "allocated_words: " (clean_escape_sequences line)) ->
-       prerr_endline line;
-       go false
-    | _, line ->
-       (* There may be some escape characters which need printing on allocated_words *)
-       prerr_string (escape_sequences_only line);
-       let line = clean_escape_sequences line in
-       let key, value = break ':' line in
-       match key with
-       | "mean_space_overhead" -> 
-       let value = float_of_string value in
-       (key, `Float value) :: go true
-       | _ ->
-       let value = int_of_string value in
-       (key, `Int value) :: go true
-       in
+    match (found_stats, input_line ic) with
+    | exception End_of_file ->
+        close_in ic ; []
+    | false, line
+      when not (starts_with "allocated_words: " (clean_escape_sequences line))
+      ->
+        prerr_endline line ; go false
+    | _, line -> (
+        (* There may be some escape characters which need printing on allocated_words *)
+        prerr_string (escape_sequences_only line) ;
+        let line = clean_escape_sequences line in
+        let key, value = break ':' line in
+        match key with
+        | "mean_space_overhead" ->
+            let value = float_of_string value in
+            (key, `Float value) :: go true
+        | _ ->
+            let value = int_of_string value in
+            (key, `Int value) :: go true )
+  in
   `Assoc (go false)
+
+let exec_prog profiling output_name prog cmdline env stdin stdout stderr =
+  if profiling then (
+    let pid, parent_ready =
+      Profiler.create_process_env_paused prog cmdline env stdin stdout stderr
+    in
+    let result = Profiler.start_profiling pid parent_ready in
+    Profiler.write_profiling_result output_name result ;
+    pid )
+  else Unix.create_process_env prog cmdline env stdin stdout stderr
 
 let run output input cmdline =
   let prog = List.hd cmdline in
   (* workaround for the lack of execve *)
-  let prog = if Filename.is_implicit prog && Sys.file_exists prog then
-               "./" ^ prog else prog in
+  let prog =
+    if Filename.is_implicit prog && Sys.file_exists prog then "./" ^ prog
+    else prog
+  in
   try
+    let profiling =
+      match Sys.getenv_opt "ORUN_CONFIG_PROFILE" with
+      | None ->
+          false
+      | Some _ ->
+          true
+    in
     let before = Unix.gettimeofday () in
     let captured_stderr_filename = Filename.temp_file "orun" "stderr" in
-    let stderr_fd = Unix.openfile captured_stderr_filename [Unix.O_WRONLY] 0600 in
-    let process_stdin = match input with 
-      | Some stdin_file -> Unix.openfile stdin_file [] 0600
-      | None -> Unix.stdin
-      in
-    let environ = "OCAMLRUNPARAM=v=0x400" ::
-      List.filter (fun s -> not (starts_with s "OCAMLRUNPARAM=")) (Array.to_list (Unix.environment ())) in
-    let pid = Unix.(create_process_env prog (Array.of_list cmdline) (Array.of_list environ) process_stdin stdout stderr_fd) in
-    Unix.close stderr_fd;
-    let { status; user_secs; sys_secs; maxrss_kB } = wait4 pid in
-    let status = match status with
-        (* hack because Unix.create_process has terrible error handling :( *)
-      | WEXITED 127 -> raise (Unix.Unix_error (Unix.ENOENT, "exec", prog))
-      | WEXITED n -> n
-      | WSTOPPED _ -> failwith "WSTOPPED but not WUNTRACED?"
-      | WSIGNALED s -> Unix.kill (Unix.getpid ()) s; assert false in
+    let stderr_fd =
+      Unix.openfile captured_stderr_filename [Unix.O_WRONLY] 0600
+    in
+    let process_stdin =
+      match input with
+      | Some stdin_file ->
+          Unix.openfile stdin_file [] 0600
+      | None ->
+          Unix.stdin
+    in
+    let name =
+      if Filename.check_suffix output ".bench" then
+        Filename.chop_suffix output ".bench"
+      else output
+    in
+    let environ =
+      "OCAMLRUNPARAM=v=0x400"
+      :: List.filter
+           (fun s -> not (starts_with s "OCAMLRUNPARAM="))
+           (Array.to_list (Unix.environment ()))
+    in
+    let pid =
+      exec_prog profiling name prog (Array.of_list cmdline)
+        (Array.of_list environ) process_stdin Unix.stdout stderr_fd
+    in
+    Unix.close stderr_fd ;
+    let {status; user_secs; sys_secs; maxrss_kB} = wait4 pid in
+    let status =
+      match status with
+      (* hack because Unix.create_process has terrible error handling :( *)
+      | WEXITED 127 ->
+          raise (Unix.Unix_error (Unix.ENOENT, "exec", prog))
+      | WEXITED n ->
+          n
+      | WSTOPPED _ ->
+          failwith "WSTOPPED but not WUNTRACED?"
+      | WSIGNALED s ->
+          Unix.kill (Unix.getpid ()) s ;
+          assert false
+    in
     let after = Unix.gettimeofday () in
-    let name = if Filename.check_suffix output ".bench" then Filename.chop_suffix output ".bench" else output in
-    let stats = [
-      "name", `String name;
-      "command", `String (quote_cmd cmdline);
-      "time_secs", `Float (after -. before);
-      "user_time_secs", `Float user_secs;
-      "sys_time_secs", `Float sys_secs;
-      "maxrss_kB", `Int maxrss_kB;
-      "ocaml", get_ocaml_config ();
-      "gc", gc_stats captured_stderr_filename;
-    ] in
+    let stats =
+      [ ("name", `String name)
+      ; ("command", `String (quote_cmd cmdline))
+      ; ("time_secs", `Float (after -. before))
+      ; ("user_time_secs", `Float user_secs)
+      ; ("sys_time_secs", `Float sys_secs)
+      ; ("maxrss_kB", `Int maxrss_kB)
+      ; ("ocaml", get_ocaml_config ())
+      ; ("gc", gc_stats captured_stderr_filename) ]
+    in
     let extra_config =
-      Unix.environment ()
-      |> Array.to_list
+      Unix.environment () |> Array.to_list
       |> List.filter (starts_with "ORUN_CONFIG_")
-      |> List.map (fun s -> let (k, v) = break '=' s in chop_prefix "ORUN_CONFIG_" k, `String v) in
+      |> List.map (fun s ->
+             let k, v = break '=' s in
+             (chop_prefix "ORUN_CONFIG_" k, `String v) )
+    in
     let stats = `Assoc (stats @ extra_config) in
-    Sys.remove captured_stderr_filename;
+    Sys.remove captured_stderr_filename ;
     let oc = open_out output in
-    Yojson.Basic.to_channel oc stats;
-    output_string oc "\n";
-    close_out oc;
+    Yojson.Basic.to_channel oc stats ;
+    output_string oc "\n" ;
+    close_out oc ;
     status
-  with
-    Unix.Unix_error (err, fn, arg) ->
-      Printf.fprintf stderr "%s: %s\n%!" (Unix.error_message err)
-        (if arg = "" then fn else arg);
-      exit 127
+  with Unix.Unix_error (err, fn, arg) ->
+    Printf.fprintf stderr "%s: %s\n%!" (Unix.error_message err)
+      (if arg = "" then fn else arg) ;
+    exit 127
 
 open Cmdliner
 
@@ -190,14 +260,14 @@ let input =
   let doc = "Optional file to use as stdin" in
   Arg.(value & opt (some string) None & info ["i"; "input"] ~docv:"FILE" ~doc)
 
-let target =
-  Arg.(non_empty & pos_all string [] & info [] ~docv:"PROG")
+let target = Arg.(non_empty & pos_all string [] & info [] ~docv:"PROG")
 
 let prog =
   let info =
     let doc = "run an OCaml program, measuring its runtime and memory use" in
     let man = [] in
-    Term.info "orun" ~version:"v0.1" ~doc ~man in
+    Term.info "orun" ~version:"v0.1" ~doc ~man
+  in
   (Term.(const run $ output $ input $ target), info)
 
 let () = Term.exit_status (Term.eval prog)

--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -48,7 +48,7 @@ let break ch s =
   (trim (sub s 0 i), trim (sub s (i + 1) (String.length s - (i + 1))))
 
 let chop_prefix pfx s =
-  assert (starts_with pfx s) ;
+  assert (starts_with pfx s);
   String.sub s (String.length pfx) (String.length s - String.length pfx)
 
 let get_ocaml_config () =

--- a/orun/profiler.c
+++ b/orun/profiler.c
@@ -321,6 +321,7 @@ value ml_unpause_and_start_profiling(value ml_pid, value ml_pipe_fds, value samp
     pe.mmap = 1;
     pe.mmap2 = 1;
     pe.wakeup_events = 1;
+    pe.precise_ip = 2;
 
     perf_fd = perf_event_open(&pe, pid, -1, -1, 0);
 

--- a/orun/profiler.c
+++ b/orun/profiler.c
@@ -1,0 +1,448 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/bigarray.h>
+#include <caml/callback.h>
+
+#ifdef __linux__
+#include <linux/perf_event.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <asm/unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <err.h>
+#include <sys/stat.h>
+#include <poll.h>
+#include <fcntl.h>
+#include <elfutils/libdwfl.h>
+#include <limits.h>
+
+#define DATA_PAGES 1024
+
+struct sample_id
+{
+    uint32_t pid;
+    uint32_t tid;
+    uint64_t time;
+};
+
+struct perf_event_record_mmap2
+{
+    struct perf_event_header header;
+    uint32_t pid;
+    uint32_t tid;
+    uint64_t addr;
+    uint64_t len;
+    uint64_t pgoff;
+    uint32_t maj;
+    uint32_t min;
+    uint64_t ino;
+    uint64_t ino_generation;
+    uint32_t prot;
+    uint32_t flags;
+    char filename[];
+};
+
+struct read_format
+{
+    uint64_t value;        /* The value of the event */
+    uint64_t time_enabled; /* if PERF_FORMAT_TOTAL_TIME_ENABLED */
+    uint64_t time_running; /* if PERF_FORMAT_TOTAL_TIME_RUNNING */
+    uint64_t id;           /* if PERF_FORMAT_ID */
+};
+
+struct perf_event_record_sample
+{
+    struct perf_event_header header;
+    uint64_t ip;   /* if PERF_SAMPLE_IP */
+    uint32_t pid;  /* if PERF_SAMPLE_TID */
+    uint32_t tid;  /* if PERF_SAMPLE_TID */
+    uint64_t time; /* if PERF_SAMPLE_TIME */
+    uint32_t cpu;  /* if PERF_SAMPLE_CPU */
+    uint32_t res;  /* if PERF_SAMPLE_CPU */
+    uint64_t bnr;  /* if PERF_SAMPLE_CALLCHAIN */
+};
+
+long perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                     int cpu, int group_fd, unsigned long flags)
+{
+    int ret;
+
+    ret = syscall(__NR_perf_event_open, hw_event, pid, cpu,
+                  group_fd, flags);
+    return ret;
+}
+
+int poll_event(int fd)
+{
+    struct pollfd pfd = {.fd = fd, .events = POLLIN | POLLHUP};
+
+    int ret = poll(&pfd, 1, 1000);
+
+    return pfd.revents;
+}
+
+value some(value contents)
+{
+    CAMLparam1(contents);
+    CAMLlocal1(option);
+
+    option = caml_alloc(1, 0);
+
+    Store_field(option, 0, contents);
+
+    CAMLreturn(option);
+}
+
+int get_line_info(Dwfl *dwfl, uint64_t ip, const char **ip_filename, const char **ip_comp_dir, const char **ip_function_name, Dwarf_Addr *addr, int *ip_lineno)
+{
+    Dwfl_Module *module = dwfl_addrmodule(dwfl, ip);
+
+    dwfl_module_relocate_address(module, addr);
+
+    *ip_function_name = dwfl_module_addrname(module, ip);
+
+    Dwfl_Line *line = dwfl_getsrc(dwfl, ip);
+
+    if (line != NULL)
+    {
+        const char *filename = dwfl_lineinfo(line, NULL, ip_lineno, NULL, NULL, NULL);
+
+        if (filename != NULL)
+        {
+            const char *comp_dir = dwfl_line_comp_dir(line);
+
+            *ip_filename = filename;
+            *ip_comp_dir = comp_dir;
+        }
+    }
+}
+
+value get_source_line_for_ip(Dwfl *dwfl, uint64_t ip)
+{
+    CAMLparam0();
+    CAMLlocal1(source_line_record);
+
+    const char *filename = NULL;
+    const char *comp_dir = NULL;
+    const char *function_name = NULL;
+    int lineno = -1;
+
+    Dwarf_Addr addr = ip;
+
+    get_line_info(dwfl, ip, &filename, &comp_dir, &function_name, &addr, &lineno);
+
+    source_line_record = caml_alloc(5, 0);
+
+    if (function_name != NULL)
+    {
+        Store_field(source_line_record, 1, some(caml_copy_string(function_name)));
+    }
+    else
+    {
+        Store_field(source_line_record, 1, Val_unit);
+    }
+
+    if (filename != NULL)
+    {
+        int filename_length = strlen(filename);
+
+        char *resolved_path = NULL;
+
+        if (filename_length > 0 && filename[0] != '/' && comp_dir != NULL)
+        {
+            char full_path[filename_length + strlen(comp_dir) + 2];
+
+            strcpy(full_path, comp_dir);
+            strcat(full_path, "/");
+            strcat(full_path, filename);
+
+            resolved_path = realpath(full_path, NULL);
+
+            if (resolved_path == NULL)
+            {
+                Store_field(source_line_record, 0, some(caml_copy_string(full_path)));
+            }
+            else
+            {
+                Store_field(source_line_record, 0, some(caml_copy_string(resolved_path)));
+                free(resolved_path);
+            }
+        }
+        else
+        {
+            resolved_path = realpath(filename, NULL);
+
+            if (resolved_path == NULL)
+            {
+                Store_field(source_line_record, 0, some(caml_copy_string(filename)));
+            }
+            else
+            {
+                Store_field(source_line_record, 0, some(caml_copy_string(resolved_path)));
+                free(resolved_path);
+            }
+        }
+    }
+    else
+    {
+        Store_field(source_line_record, 0, Val_unit);
+    }
+
+    Store_field(source_line_record, 2, Val_int(lineno));
+    Store_field(source_line_record, 3, Val_int(addr));
+
+    CAMLreturn(source_line_record);
+
+    CAMLreturn(Val_unit);
+}
+
+int read_event(uint32_t type, unsigned char *buf, value sample_callback, Dwfl *dwfl, pid_t child_pid, int *sample_id)
+{
+    CAMLparam1(sample_callback);
+    CAMLlocal5(sample_record, branches_head, branches_entry, source_line_option, callback_return);
+
+    if (type == PERF_RECORD_MMAP2)
+    {
+        struct perf_event_record_mmap2 *record = (struct perf_event_record_mmap2 *)buf;
+
+        dwfl_report_begin_add(dwfl);
+
+        Dwfl_Module *module = dwfl_report_elf(dwfl, (const char *)record->filename, (const char *)record->filename, -1, record->addr - record->pgoff, false);
+
+        dwfl_report_end(dwfl, NULL, NULL);
+    }
+    else if (type == PERF_RECORD_EXIT)
+    {
+        CAMLdrop;
+        return 0;
+    }
+    else if (type == PERF_RECORD_SAMPLE)
+    {
+        struct perf_event_record_sample *record = (struct perf_event_record_sample *)buf;
+
+        unsigned char *pos = buf + sizeof(struct perf_event_record_sample);
+
+        source_line_option = get_source_line_for_ip(dwfl, record->ip);
+
+        sample_record = caml_alloc(6, 0);
+        Store_field(sample_record, 0, source_line_option);
+
+        branches_head = Val_unit;
+
+        // walk branch stack now and add these
+        uint64_t branches = record->bnr;
+
+        for (int c = 0; c < branches; c++)
+        {
+            struct perf_branch_entry *entry = (struct perf_branch_entry *)pos;
+
+            uint64_t from_ip = entry->from;
+
+            source_line_option = get_source_line_for_ip(dwfl, from_ip);
+
+            branches_entry = caml_alloc(2, 0);
+
+            Store_field(branches_entry, 0, source_line_option);
+            Store_field(branches_entry, 1, branches_head);
+
+            branches_head = branches_entry;
+
+            pos += sizeof(struct perf_branch_entry);
+        }
+
+        Store_field(sample_record, 1, branches_head);
+        Store_field(sample_record, 2, Val_int(record->time));
+        Store_field(sample_record, 3, Val_int(record->tid));
+        Store_field(sample_record, 4, Val_int(record->cpu));
+        Store_field(sample_record, 5, Val_int(*sample_id));
+
+        (*sample_id)++;
+
+        callback_return = caml_callback(sample_callback, sample_record);
+    }
+
+    CAMLdrop;
+    return 1;
+}
+
+value ml_unpause_and_start_profiling(value ml_pid, value ml_pipe_fds, value sample_callback)
+{
+    CAMLparam3(ml_pid, ml_pipe_fds, sample_callback);
+
+    int parent_ready_write = Long_val(ml_pipe_fds);
+
+    int sample_id = 0;
+
+    // Set up DWARF stuff
+    static char *debuginfo_path;
+
+    static const Dwfl_Callbacks offline_callbacks =
+        {
+            .find_debuginfo = dwfl_standard_find_debuginfo,
+            .debuginfo_path = &debuginfo_path,
+            .section_address = dwfl_offline_section_address,
+            .find_elf = dwfl_build_id_find_elf,
+        };
+
+    struct Dwfl *dwfl = dwfl_begin(&offline_callbacks);
+
+    struct mmap_node *head_ptr = NULL;
+
+    pid_t pid = Long_val(ml_pid);
+
+    struct perf_event_attr pe;
+    int perf_fd;
+    struct perf_event_mmap_page *header;
+    unsigned char *base, *data;
+    int page_size = getpagesize();
+
+    memset(&pe, 0, sizeof(struct perf_event_attr));
+
+    pe.type = 0;
+    pe.size = sizeof(pe);
+    pe.sample_type = PERF_SAMPLE_IP | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU | PERF_SAMPLE_TID | PERF_SAMPLE_BRANCH_STACK;
+    pe.branch_sample_type = PERF_SAMPLE_BRANCH_USER | PERF_SAMPLE_BRANCH_CALL_STACK;
+    pe.sample_freq = 3000;
+    pe.freq = 1;
+    pe.exclude_kernel = 1;
+    pe.exclude_hv = 1;
+    pe.exclude_guest = 1;
+    pe.enable_on_exec = 1;
+    pe.disabled = 1;
+    pe.task = 1;
+    pe.mmap = 1;
+    pe.mmap2 = 1;
+    pe.wakeup_events = 1;
+
+    perf_fd = perf_event_open(&pe, pid, -1, -1, 0);
+
+    if (perf_fd < 0)
+    {
+        perror("perf_event_open");
+        return -1;
+    }
+
+    uint64_t mmap_size = (1 + DATA_PAGES) * page_size;
+    base = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, perf_fd, 0);
+
+    if (base == MAP_FAILED)
+    {
+        printf("mmap failed: %d\n", perf_fd);
+        err(EXIT_FAILURE, "mmap");
+    }
+
+    header = (struct perf_event_mmap_page *)base;
+    data = base + header->data_offset;
+
+    // Tell child we're ready
+    char *go = "!";
+
+    while (1)
+    {
+        int ret = write(parent_ready_write, go, 1);
+
+        if (ret < 0)
+        {
+            if (errno == EAGAIN || errno == EINTR)
+            {
+                continue;
+            }
+            else
+            {
+                perror("write");
+                exit(-1);
+            }
+        }
+
+        break;
+    }
+
+    pid_t child_pid = Int_val(ml_pid);
+    uint64_t data_read = 0;
+
+    while (1)
+    {
+        uint64_t original_tail = header->data_tail;
+        uint64_t tail = original_tail;
+        uint64_t original_head = __atomic_load_n(&header->data_head, __ATOMIC_ACQUIRE);
+        uint64_t head = original_head;
+
+        if ((head - tail) % header->data_size == 0)
+        {
+            // Ring buffer is empty, let's wait for something interesting to happen
+            int revents = poll_event(perf_fd);
+
+            if ((revents & POLLHUP) && (__atomic_load_n(&header->data_head, __ATOMIC_ACQUIRE) - tail) % header->data_size == 0)
+            {
+                break;
+            }
+
+            // Right, time to go check things again
+            continue;
+        }
+
+        head = head % header->data_size;
+        tail = tail % header->data_size;
+
+        struct perf_event_header *event_header = (struct perf_event_header *)(data + tail);
+
+        int space_left_in_ring = header->data_size - (tail + event_header->size);
+
+        if (space_left_in_ring < 0)
+        {
+            // Slow path, need to copy the data out first
+            unsigned char buffer[event_header->size];
+
+            int remaining = header->data_size - tail;
+
+            memcpy(buffer, data + tail, remaining);
+            memcpy(buffer + remaining, data, event_header->size - remaining);
+
+            int status = read_event(event_header->type, buffer, sample_callback, dwfl, child_pid, &sample_id);
+
+            if (status == 0)
+            {
+                break; // Success
+            }
+        }
+        else
+        {
+            // Fast path, can just hand the memory straight from the ring
+            int status = read_event(event_header->type, data + tail, sample_callback, dwfl, child_pid, &sample_id);
+
+            if (status == 0)
+            {
+                break; // Success
+            }
+        }
+
+        data_read += event_header->size;
+
+        __atomic_store_n(&header->data_tail, original_tail + event_header->size, __ATOMIC_RELEASE);
+    }
+
+    close(perf_fd);
+    munmap(base, (1 + DATA_PAGES) * page_size);
+
+    dwfl_end(dwfl);
+
+    CAMLreturn(Val_unit);
+}
+#endif
+
+#ifdef __APPLE__
+value ml_unpause_and_start_profiling(value ml_pid, value ml_pipe_fds)
+{
+    CAMLparam2(ml_pid, ml_pipe_fds);
+
+    CAMLreturn(Val_unit);
+}
+#endif

--- a/orun/profiler.ml
+++ b/orun/profiler.ml
@@ -1,0 +1,244 @@
+open Printf
+open Common
+
+external unpause_and_start_profiling :
+  int -> Unix.file_descr -> (sample -> unit) -> unit
+  = "ml_unpause_and_start_profiling"
+
+exception ExpectedSome
+
+let unwrap = function None -> raise ExpectedSome () | Some x -> x
+
+let agg_hash = Hashtbl.create 1000
+
+let update_line src_line self_time_inc total_time_inc =
+  match Hashtbl.find_opt agg_hash src_line with
+  | None ->
+      Hashtbl.add agg_hash src_line {self_time= 1; total_time= 1}
+  | Some x ->
+      x.self_time <- x.self_time + self_time_inc ;
+      x.total_time <- x.total_time + total_time_inc
+
+let rec update_lines = function
+  | [] ->
+      ()
+  | h :: t ->
+      update_line h 0 1 ; update_lines t
+
+let src_line_to_idx = Hashtbl.create 10000
+
+let find_src_line_idx src_line =
+  match Hashtbl.find_opt src_line_to_idx src_line with
+  | None ->
+      let new_idx = Hashtbl.length src_line_to_idx in
+      Hashtbl.add src_line_to_idx src_line new_idx ;
+      new_idx
+  | Some x ->
+      x
+
+let samples_list = ref []
+
+let sample_callback sample =
+  (* increment self for the current source line *)
+  update_line sample.current 1 1 ;
+  update_lines sample.call_stack ;
+  let new_stack = List.map (fun a -> find_src_line_idx a) sample.call_stack in
+  let compressed_stack =
+    { stack= find_src_line_idx sample.current :: List.rev new_stack
+    ; thread_id= sample.thread_id
+    ; cpu= sample.cpu
+    ; timestamp= sample.timestamp
+    ; id= sample.id }
+  in
+  samples_list := compressed_stack :: !samples_list
+
+let start_profiling pid pipe_fd =
+  unpause_and_start_profiling pid pipe_fd sample_callback ;
+  agg_hash
+
+let int_of_fd (x : Unix.file_descr) : int = Obj.magic x
+
+let rec file_descr_not_standard (fd : Unix.file_descr) =
+  if int_of_fd fd >= 3 then fd else file_descr_not_standard (Unix.dup fd)
+
+let safe_close fd = try Unix.close fd with Unix.Unix_error (_, _, _) -> ()
+
+let perform_redirections new_stdin new_stdout new_stderr =
+  let new_stdin = file_descr_not_standard new_stdin in
+  let new_stdout = file_descr_not_standard new_stdout in
+  let new_stderr = file_descr_not_standard new_stderr in
+  (*  The three dup2 close the original stdin, stdout, stderr,
+      which are the descriptors possibly left open
+      by file_descr_not_standard *)
+  Unix.dup2 ~cloexec:false new_stdin Unix.stdin ;
+  Unix.dup2 ~cloexec:false new_stdout Unix.stdout ;
+  Unix.dup2 ~cloexec:false new_stderr Unix.stderr ;
+  safe_close new_stdin ;
+  safe_close new_stdout ;
+  safe_close new_stderr
+
+let rec wait_for_parent parent_ready =
+  let read_fds, _write_fds, _exception_fds =
+    Unix.select [parent_ready] [] [] (-1.0)
+  in
+  if List.mem parent_ready read_fds then () else wait_for_parent parent_ready
+
+let create_process_env_paused cmd args env new_stdin new_stdout new_stderr =
+  let parent_ready, parent_ready_write = Unix.pipe () in
+  match Unix.fork () with
+  | 0 -> (
+    try
+      perform_redirections new_stdin new_stdout new_stderr ;
+      wait_for_parent parent_ready ;
+      Unix.execvpe cmd args env
+    with _ -> exit 127 )
+  | id ->
+      (id, parent_ready_write)
+
+module StringMap = Map.Make (String)
+
+module IntMap = Map.Make (struct
+  type t = int
+
+  let compare = Pervasives.compare
+end)
+
+let slash_regex = Str.regexp "[/\.]"
+
+let add_to_line_list src_line counts l =
+  match l with
+  | None ->
+      Some [(src_line, counts)]
+  | Some v ->
+      Some ((src_line, counts) :: v)
+
+let group_by_source_file src_line counts m =
+  match src_line.filename with
+  | None ->
+      m
+  | Some f ->
+      StringMap.update f
+        (function
+          | None ->
+              Some (IntMap.add src_line.line [(src_line, counts)] IntMap.empty)
+          | Some l ->
+              Some
+                (IntMap.update src_line.line
+                   (add_to_line_list src_line counts)
+                   l) )
+        m
+
+let map_some f l =
+  List.map
+    (fun x -> f (unwrap x))
+    (List.filter (function None -> false | Some _ -> true) l)
+
+let source_line_counts_to_json (filename, function_name) (counts, lc) =
+  `Assoc
+    [ ("filename", `String filename)
+    ; ("function", `String function_name)
+    ; ("self_time", `Int counts.self_time)
+    ; ("total_time", `Int counts.total_time)
+    ; ( "line_counts"
+      , `List
+          ( match lc with
+          | None ->
+              []
+          | Some line_counts ->
+              List.map
+                (fun (line, count) ->
+                  `List [`Int line; `Int count.self_time; `Int count.total_time]
+                  )
+                (List.sort (fun (a, _) (b, _) -> a - b) line_counts) ) ) ]
+
+let hotspots_to_json hotspots =
+  `List (List.map (fun (k, v) -> source_line_counts_to_json k v) hotspots)
+
+let group_by (f : 'a -> 'b) (ll : 'a list) : ('b, 'a list) Hashtbl.t =
+  List.fold_left
+    (fun acc e ->
+      let grp = f e in
+      let grp_mems = try Hashtbl.find acc grp with Not_found -> [] in
+      Hashtbl.replace acc grp (e :: grp_mems) ;
+      acc )
+    (Hashtbl.create 100) ll
+
+let fold_groups (f : 'b -> 'a list -> 'c) (g : ('b, 'a list) Hashtbl.t) :
+    ('b, 'c) Hashtbl.t =
+  Hashtbl.fold
+    (fun a b m ->
+      Hashtbl.add m a (f a b) ;
+      m )
+    g (Hashtbl.create 100)
+
+let flatten h = Hashtbl.fold (fun a b c -> (a, b) :: c) h []
+
+let group_by_fold (f : 'a -> 'b) (l : 'a list) (f2 : 'b -> 'a list -> 'c) :
+    ('b * 'c) list =
+  let grouped = group_by f l in
+  flatten (fold_groups f2 grouped)
+
+let write_profiling_result output_name (agg_result : aggregate_result) =
+  (* first write out the json representation of results *)
+  let total_samples =
+    Hashtbl.fold (fun a b c -> c + b.self_time) agg_result 0
+  in
+  let key_values = flatten agg_result in
+  let only_present_filenames =
+    List.filter
+      (function
+        | {filename= None}, _ ->
+            false
+        | {filename= Some x}, _ ->
+            Sys.file_exists x )
+      key_values
+  in
+  (* calculate hotspots *)
+  let grouped_by_file_function =
+    group_by
+      (fun (k, v) ->
+        (get_or "unknown" k.filename, get_or "unknown" k.function_name) )
+      key_values
+  in
+  let sum_counts l =
+    List.fold_left
+      (fun s (k, v) ->
+        s.self_time <- s.self_time + v.self_time ;
+        s.total_time <- s.total_time + v.total_time ;
+        s )
+      {self_time= 0; total_time= 0}
+      l
+  in
+  let sum_counts_by_file_function =
+    fold_groups (fun _ l -> sum_counts l) grouped_by_file_function
+  in
+  let sum_counts_by_line =
+    fold_groups
+      (fun _ l ->
+        group_by_fold (fun (k, v) -> k.line) l (fun _ cs -> sum_counts cs) )
+      grouped_by_file_function
+  in
+  let hottest_file_functions =
+    take
+      (List.sort
+         (fun (k0, v0) (k1, v1) -> v1.self_time - v0.self_time)
+         (flatten sum_counts_by_file_function))
+      20
+  in
+  let hotspots =
+    List.map
+      (fun (ff, c) -> (ff, (c, Hashtbl.find_opt sum_counts_by_line ff)))
+      hottest_file_functions
+  in
+  let profile_out = open_out_bin (output_name ^ ".prof.json") in
+  let hotspots_json =
+    `Assoc
+      [ ("total_samples", `Int total_samples)
+      ; ("hotspots", hotspots_to_json hotspots) ]
+  in
+  Yojson.Basic.to_channel profile_out hotspots_json ;
+  close_out profile_out ;
+  let dir_name = output_name ^ "_prof_results" in
+  if not (Sys.file_exists dir_name) then Unix.mkdir dir_name 0o740 ;
+  Reports.render_hotspots_html output_name hotspots total_samples ;
+  Reports.render_trace_json output_name !samples_list src_line_to_idx

--- a/orun/profiler.mli
+++ b/orun/profiler.mli
@@ -1,0 +1,12 @@
+val create_process_env_paused :
+     string
+  -> string array
+  -> string array
+  -> Unix.file_descr
+  -> Unix.file_descr
+  -> Unix.file_descr
+  -> int * Unix.file_descr
+
+val start_profiling : int -> Unix.file_descr -> Common.aggregate_result
+
+val write_profiling_result : string -> Common.aggregate_result -> unit

--- a/orun/reports.ml
+++ b/orun/reports.ml
@@ -1,0 +1,164 @@
+open Printf
+open Common
+
+let css =
+  {|
+        .outer-container { max-width: 1700px; margin: 0 auto }
+        .gray-row { background-color: rgb(250, 250, 250) }
+        .hotspot-row { padding: 15px; }
+        .source_code { font-family: Menlo, Monaco, Consolas, "Courier New"; font-size: 14pt; }
+|}
+
+let common_header name =
+  sprintf
+    {|
+<!DOCTYPE html><html><head>
+<title>%s</title>
+<style>%s</style>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.4.1/dist/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+</head><body><div class="outer-container"><div class="container-fluid"><h3>Hotspots %s</h3>
+<div class="hotspot-row row"><div class="col-xs-4"><b>File</b></div><div class="col-xs-3"><b>Function</b></div><div class="col-xs-2"><b>Self time</b></div><div class="col-xs-2"><b>Total time</b></div></div>
+|}
+    name css name
+
+let common_footer = "</div></div></body></html>"
+
+let shrink_file_location f =
+  String.concat "/" (List.rev (take (List.rev (String.split_on_char '/' f)) 3))
+
+let tab_regex = Str.regexp "\t"
+
+let space_regex = Str.regexp " "
+
+let replace_tabs_and_spaces s =
+  Str.global_replace space_regex "&nbsp;"
+    (Str.global_replace tab_regex "&nbsp;" s)
+
+let render_hotspot output total_samples idx
+    ((file, function_name), ((counts : counts), line_counts_option)) =
+  fprintf output
+    {|<div class="hotspot-row %s row"><div class="col-xs-4"><a data-toggle="tooltip" title="%s">%s</a></div><div class="col-xs-3">%s</div><div class="col-xs-2">%d (%d%%)</div><div class="col-xs-2">%d (%d%%)</div><div class="col-xs-1"><button id="view_source_%d" class="btn btn-xs">View source</button></div></div>
+    <script>
+    $("#view_source_%d").click(function(){
+      $("#source_%d").toggle();
+    });
+    </script>|}
+    (if idx mod 2 == 0 then "gray-row" else "")
+    file
+    (shrink_file_location file)
+    function_name counts.self_time
+    (100 * counts.self_time / total_samples)
+    counts.total_time
+    (100 * counts.total_time / total_samples)
+    idx idx idx ;
+  (* find min and max lines if there's any line info *)
+  match line_counts_option with
+  | Some line_counts ->
+      if Sys.file_exists file then (
+        let min_line =
+          List.fold_left
+            (fun a (line, _) -> if line < a then line else a)
+            max_int line_counts
+          - 5
+        in
+        let max_line =
+          List.fold_left
+            (fun a (line, _) -> if line > a then line else a)
+            min_int line_counts
+          + 5
+        in
+        let original_src = open_in file in
+        let current_line = ref 1 in
+        try
+          fprintf output
+            {| <div id="source_%d" class="row" style="display: none;"><div class="col-xs-offset-1 col-xs-10"> |}
+            idx ;
+          while true do
+            let assoc_opt = List.assoc_opt !current_line line_counts in
+            let self_time =
+              match assoc_opt with Some c -> c.self_time | None -> 0
+            in
+            let total_time =
+              match assoc_opt with Some c -> c.total_time | None -> 0
+            in
+            let src_line = input_line original_src in
+            let html_line = replace_tabs_and_spaces src_line in
+            if !current_line >= min_line && !current_line <= max_line then
+              fprintf output
+                {| <div id="source_%d_%d" class="source_code row %s"><div class="col-xs-1 text-right">%d</div><div class="col-xs-9">%s</div><div class="col-xs-1 text-left">%d</div><div class="col-xs-1 text-left">%d</div></div> |}
+                idx !current_line
+                (if !current_line mod 2 == 0 then "" else "gray-row")
+                !current_line html_line self_time total_time ;
+            incr current_line
+          done
+        with End_of_file ->
+          fprintf output {| </div></div> |} ;
+          close_in original_src )
+      else
+        fprintf output "<style>#view_source_%d { display: none; }</style>" idx
+  | None ->
+      fprintf output "<style>#view_source_%d { display: none; }</style>" idx
+
+let render_hotspots_html output_name hotspots total_samples =
+  let hotspots_file = open_out (output_name ^ "_prof_results/hotspots.html") in
+  fprintf hotspots_file "%s" (common_header output_name) ;
+  List.iteri (render_hotspot hotspots_file total_samples) hotspots
+
+let generate_stacks stack_idxs sample =
+  let max_idx = List.length sample.stack - 1 in
+  let stack_json =
+    List.mapi
+      (fun depth stack ->
+        let src_line = Hashtbl.find stack_idxs stack in
+        let category =
+          match src_line.filename with
+          | None ->
+              "unknown"
+          | Some x ->
+              Filename.basename x
+        in
+        let name = get_or "unknown" src_line.function_name in
+        let base_list = [("name", `String (category ^ ":" ^ name))] in
+        let related_list =
+          match depth with
+          | x when x = max_idx ->
+              base_list
+          | n ->
+              ( "parent"
+              , `String (string_of_int sample.id ^ "_" ^ string_of_int (n + 1))
+              )
+              :: base_list
+        in
+        ( string_of_int sample.id ^ "_" ^ string_of_int depth
+        , `Assoc related_list ) )
+      sample.stack
+  in
+  stack_json
+
+let generate_all_stacks stack_idxs samples =
+  List.flatten (List.map (generate_stacks stack_idxs) samples)
+
+let convert_sample stack_idxs sample =
+  `Assoc
+    [ ("cpu", `Int sample.cpu)
+    ; ("tid", `Int sample.thread_id)
+    ; ("ts", `Float (float_of_int sample.timestamp))
+    ; ("name", `String "perf-cpu")
+    ; ("sf", `String (string_of_int sample.id ^ "_0"))
+    ; ("weight", `Int 1) ]
+
+let stack_frames samples stack_idxs =
+  List.map (convert_sample stack_idxs) samples
+
+let render_trace_json output_name samples stack_idxs =
+  let inverted_idxs = invert_hashtbl stack_idxs in
+  let output_file = open_out (output_name ^ "_prof_results/trace.json") in
+  let trace_json =
+    `Assoc
+      [ ("traceEvents", `List [])
+      ; ("samples", `List (stack_frames samples inverted_idxs))
+      ; ("stackFrames", `Assoc (generate_all_stacks inverted_idxs samples)) ]
+  in
+  Yojson.Basic.to_channel output_file trace_json

--- a/orun/reports.mli
+++ b/orun/reports.mli
@@ -1,0 +1,10 @@
+open Common
+
+val render_trace_json :
+  string -> compressed_sample list -> (source_line, int) Hashtbl.t -> unit
+
+val render_hotspots_html :
+     string
+  -> ((string * string) * (counts * (int * counts) list option)) list
+  -> int
+  -> unit

--- a/orun/wait4.c
+++ b/orun/wait4.c
@@ -26,6 +26,7 @@ value ml_wait4(value pid)
   CAMLlocal2(st, usg);
   int wstatus;
   struct rusage usage;
+
   if (wait4(Long_val(pid), &wstatus, 0, &usage) < 0) {
     caml_failwith("wait4 failed");
   }


### PR DESCRIPTION
This PR adds initial profiling and tracing support to orun.

The intention is to have a separate sandmark iteration on each run that emits profiling, hardware counters and GC instrumentation data for each of the benchmarks to HTML reports or in formats that can easily be analysed. This can enable identifying the cause of a performance regression without having to go through the process of replicating the benchmark environment.

This PR uses the perf_event_open syscall to read profiling events and libdwfl to translate these into file/module/function/line information. It currently relies on LBR in ‘call stack’ mode to capture the call stack though in future it would probably be worth doing DWARF-based unwinding and leverage the branch timing mode of LBR instead.

Interfacing with perf_event_open directly means we can ingest multiple sources of performance data in the same run by having perf emit these to the same ring buffer, e.g having hardware counter sampling and GC instrumentation data from BPF

As it stands this PR emits a hotspot HTML report (example: https://toao.com/tmp/hotspots.html) and a JSON trace suitable for ingestion into the Chrome tracing tool (example: https://toao.com/tmp/trace.json):

![image](https://user-images.githubusercontent.com/631805/60664379-acce7400-9e59-11e9-9f6e-be96a80d71be.png)

Additional traces can be added to the output in future to allow slicing up profiling information based on events of interest (GC phases, possibly even high level application events).

To kick off an iteration of orun with profiling enabled, you need to set the environment variable ORUN_CONFIG_PROFILE and instruct sandmark to only do a single iteration (via ITER=1 parameter to the Makefile) as such:

`ORUN_CONFIG_PROFILE=y make ITER=1 ocaml-versions/4.07.1.bench`

You will need to set `/proc/sys/kernel/perf_event_paranoid` to 0 in order to do this as a non-superuser.

Also the default sampling rate is set at 3khz in this PR but we probably want to bump that higher - doing so requires tweaking a few other sysfs settings though.

This also puts a dependency on libdw-dev for sandmark, though this only applies on Linux.

I've talked to @samoht and he's interested in using this with his Irmin benchmarking work, so it may make sense to move some of this code to a separate opam package.