### PR TITLE
Workaround to use system installed dune for build 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,8 @@ steps:
   commands:
   - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
+  - eval $(opam env)
+  - opam install dune
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
   - make ocaml-versions/4.07.1.bench
@@ -19,6 +21,8 @@ steps:
   commands:
   - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
+  - eval $(opam env)
+  - opam install dune
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
   - export BENCH_TARGET=parallelbench
@@ -28,6 +32,8 @@ steps:
   commands:
   - sudo apt-get update && sudo apt-get -y install libgmp-dev m4 libdw-dev
   - sudo chown -R opam .
+  - eval $(opam env)
+  - opam install dune
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
   - export BENCH_TARGET=multibench

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,23 @@ export OPAMROOT=$(CURDIR)/_opam
 
 .PHONY: bash list clean
 
+# HACK: we are using the system installed dune to avoid breakages with
+# multicore and 4.09/trunk
+# This is a workaround for r14/4.09/trunk until better solutions arrive
+SYS_DUNE_BASE_DIR = $(subst /bin/dune,,$(shell which dune))
+
+setup_sys_dune:
+ifeq (,$(SYS_DUNE_BASE_DIR))
+	$(error Could not find a system installation of dune (try `opam install dune`?))
+else
+	rm -rf $(CURDIR)/_opam/sys_dune
+	mkdir -p $(CURDIR)/_opam/sys_dune/bin
+	mkdir -p $(CURDIR)/_opam/sys_dune/lib
+	ln -s $(SYS_DUNE_BASE_DIR)/bin/dune $(CURDIR)/_opam/sys_dune/bin/dune
+	ln -s $(SYS_DUNE_BASE_DIR)/bin/jbuilder $(CURDIR)/_opam/sys_dune/bin/jbuilder
+	ln -s $(SYS_DUNE_BASE_DIR)/lib/dune $(CURDIR)/_opam/sys_dune/lib/dune
+endif
+
 ocamls=$(wildcard ocaml-versions/*.comp)
 
 # to build in a Dockerfile you need to disable sandboxing in opam
@@ -41,7 +58,7 @@ endif
 _opam/opam-init/init.sh:
 	opam init --bare --no-setup --no-opamrc $(OPAM_INIT_EXTRA_FLAGS) ./dependencies
 
-_opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp
+_opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp setup_sys_dune
 	rm -rf dependencies/packages/ocaml/ocaml.$*
 	rm -rf dependencies/packages/ocaml-base-compiler/ocaml-base-compiler.$*
 	mkdir -p dependencies/packages/ocaml/ocaml.$*

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,13 @@ export OPAMROOT=$(CURDIR)/_opam
 # HACK: we are using the system installed dune to avoid breakages with
 # multicore and 4.09/trunk
 # This is a workaround for r14/4.09/trunk until better solutions arrive
-SYS_DUNE_BASE_DIR = $(subst /bin/dune,,$(shell which dune))
+SYS_DUNE_BASE_DIR ?= $(subst /bin/dune,,$(shell which dune))
 
 setup_sys_dune:
 ifeq (,$(SYS_DUNE_BASE_DIR))
 	$(error Could not find a system installation of dune (try `opam install dune`?))
 else
+	@echo "Linking to system dune files found at: "$(SYS_DUNE_BASE_DIR)
 	rm -rf $(CURDIR)/_opam/sys_dune
 	mkdir -p $(CURDIR)/_opam/sys_dune/bin
 	mkdir -p $(CURDIR)/_opam/sys_dune/lib

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ ifeq (,$(SYS_DUNE_BASE_DIR))
 	$(error Could not find a system installation of dune (try `opam install dune`?))
 else
 	@echo "Linking to system dune files found at: "$(SYS_DUNE_BASE_DIR)
-	rm -rf $(CURDIR)/_opam/sys_dune
-	mkdir -p $(CURDIR)/_opam/sys_dune/bin
-	mkdir -p $(CURDIR)/_opam/sys_dune/lib
+	@echo $(SYS_DUNE_BASE_DIR)"/bin/dune --version = "$(shell $(SYS_DUNE_BASE_DIR)/bin/dune --version)
+	@rm -rf $(CURDIR)/_opam/sys_dune
+	@mkdir -p $(CURDIR)/_opam/sys_dune/bin
+	@mkdir -p $(CURDIR)/_opam/sys_dune/lib
 	ln -s $(SYS_DUNE_BASE_DIR)/bin/dune $(CURDIR)/_opam/sys_dune/bin/dune
 	ln -s $(SYS_DUNE_BASE_DIR)/bin/jbuilder $(CURDIR)/_opam/sys_dune/bin/jbuilder
 	ln -s $(SYS_DUNE_BASE_DIR)/lib/dune $(CURDIR)/_opam/sys_dune/lib/dune
@@ -78,7 +79,7 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp setup_sys_dune
 .FORCE:
 ocaml-versions/%.bench: ocaml-versions/%.comp _opam/% .FORCE
 	@opam update
-	@opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
+	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 	@{ echo '(lang dune 1.0)'; \
 	   for i in `seq 1 $(ITER)`; do \
 	     echo "(context (opam (switch $*) (name $*_$$i)))"; \

--- a/dependencies/packages/dune/dune.1.7.1/opam
+++ b/dependencies/packages/dune/dune.1.7.1/opam
@@ -12,11 +12,19 @@ depends: [
 ]
 build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
-  ["ocaml" "bootstrap.ml"]
-  ["./boot.exe" "--release" "--subst"] {pinned}
-  ["./boot.exe" "--release" "-j" jobs]
+  #["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  #["ocaml" "bootstrap.ml"]
+  #["./boot.exe" "--release" "--subst"] {pinned}
+  #["./boot.exe" "--release" "-j" jobs]
 ]
+# HACK: link out to a system dune installation setup in the master makefile
+# This was done as a workaround for dune breakage with trunk until better
+# solutions arrive
+install: [
+  ["ln" "-s" "%{root}%/sys_dune/bin/dune" "%{bin}%/dune"]
+  ["ln" "-s" "%{root}%/sys_dune/bin/jbuilder" "%{bin}%/jbuilder"]
+  ["ln" "-s" "%{root}%/sys_dune/lib/dune" "%{lib}%/dune"]
+ ]
 conflicts: [
   "jbuilder" {!= "transition"}
   "odoc" {< "1.3.0"}
@@ -41,9 +49,10 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-url {
-# Temporarily redirected to stedolan/dune for multicore support
+#url {
 #  src: "https://github.com/ocaml/dune/releases/download/1.7.1/dune-1.7.1.tbz
 #  checksum: "md5=7b184c8d74ec5177f9bb2f4c4a035c4f"
-  src: "https://github.com/stedolan/dune/archive/unravel.tar.gz"
-}
+#
+# Temporarily redirected to stedolan/dune for multicore support
+#  src: "https://github.com/stedolan/dune/archive/unravel.tar.gz"
+#}

--- a/orun/config/detect_os.sh
+++ b/orun/config/detect_os.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+OUTFILE="profiler_library_flags.sexp"
+if [ "Linux" = "`uname -s`" ]; then
+	echo "(-ldw)" > ${OUTFILE}
+else
+	echo "()" > ${OUTFILE}
+fi

--- a/orun/dune
+++ b/orun/dune
@@ -16,5 +16,5 @@
 
 (rule
  (targets profiler_library_flags.sexp)
- (deps    (:detect_os config/detect_os.exe))
+ (deps    (:detect_os config/detect_os.sh))
  (action  (run %{detect_os})))


### PR DESCRIPTION
while things broken with 4.09/trunk and we need to operate over a wide range of compilers 4.06/multicore through trunk.