### PR TITLE
Try to use opam.ocaml.org/cache when we can

### DIFF
--- a/dependencies/repo
+++ b/dependencies/repo
@@ -1,1 +1,2 @@
 opam-version: "2.0"
+archive-mirrors: "https://opam.ocaml.org/cache/"


### PR DESCRIPTION
Try to get the source archives from https://opam.ocaml.org/cache when we can. Might make things a bit more robust in instances where we are failing to pull the source files. 