### PR TITLE
stdlib rebalance

### DIFF
--- a/benchmarks/stdlib/array.inc
+++ b/benchmarks/stdlib/array.inc
@@ -1,16 +1,18 @@
 (executable (name array_bench) (modules array_bench))
 
 (rule
-         (targets array_bench.array_forall.1000000.bench)
+         (targets array_bench.array_forall.1000.100000.bench)
           (deps (:prog array_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} array_forall 1000000)))
-(rule
-         (targets array_bench.array_fold.1000000.bench)
-          (deps (:prog array_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} array_fold 1000000)))
-(rule
-         (targets array_bench.array_iter.1000000.bench)
-          (deps (:prog array_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} array_iter 1000000)))
+           (action (run orun -o %{targets} -- %{prog} array_forall 1000 100000)))
 
-(alias (name bench) (deps array_bench.array_forall.1000000.bench array_bench.array_fold.1000000.bench array_bench.array_iter.1000000.bench))
+(rule
+         (targets array_bench.array_fold.1000.100000.bench)
+          (deps (:prog array_bench.exe))
+           (action (run orun -o %{targets} -- %{prog} array_fold 1000 100000)))
+
+(rule
+         (targets array_bench.array_iter.1000.100000.bench)
+          (deps (:prog array_bench.exe))
+           (action (run orun -o %{targets} -- %{prog} array_iter 1000 100000)))
+
+(alias (name bench) (deps array_bench.array_forall.1000.100000.bench array_bench.array_fold.1000.100000.bench array_bench.array_iter.1000.100000.bench))

--- a/benchmarks/stdlib/array_bench.ml
+++ b/benchmarks/stdlib/array_bench.ml
@@ -1,8 +1,10 @@
+let bench_type = Sys.argv.(1)
+let length = int_of_string Sys.argv.(2)
+let iterations = int_of_string Sys.argv.(3)
+
 let create_array size =
   let a = Array.make size 0 in
   Array.mapi (fun i _ -> i) a
-
-let length = 1000
 
 let array_iter iterations =
   let a = create_array length in
@@ -24,8 +26,7 @@ let array_fold iterations =
   done
 
 let () =
-  let iterations = int_of_string Sys.argv.(2) in
-  match Sys.argv.(1) with
+  match bench_type with
   | "array_fold" ->
       array_fold iterations
   | "array_forall" ->

--- a/benchmarks/stdlib/hashtbl.inc
+++ b/benchmarks/stdlib/hashtbl.inc
@@ -21,13 +21,13 @@
           (deps (:prog hashtbl_bench.exe))
            (action (run orun -o %{targets} -- %{prog} int_find2 10)))
 (rule
-         (targets hashtbl_bench.hashtbl_iter.100.bench)
+         (targets hashtbl_bench.hashtbl_iter.10.bench)
           (deps (:prog hashtbl_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} hashtbl_iter 100)))
+           (action (run orun -o %{targets} -- %{prog} hashtbl_iter 10)))
 (rule
-         (targets hashtbl_bench.hashtbl_fold.100.bench)
+         (targets hashtbl_bench.hashtbl_fold.10.bench)
           (deps (:prog hashtbl_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} hashtbl_fold 100)))
+           (action (run orun -o %{targets} -- %{prog} hashtbl_fold 10)))
 (rule
          (targets hashtbl_bench.hashtbl_add_resizing.1000000.bench)
           (deps (:prog hashtbl_bench.exe))
@@ -49,8 +49,8 @@
           (deps (:prog hashtbl_bench.exe))
            (action (run orun -o %{targets} -- %{prog} hashtbl_find 1000000)))
 (rule
-         (targets hashtbl_bench.hashtbl_filter_map.100.bench)
+         (targets hashtbl_bench.hashtbl_filter_map.10.bench)
           (deps (:prog hashtbl_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} hashtbl_filter_map 100)))
+           (action (run orun -o %{targets} -- %{prog} hashtbl_filter_map 10)))
 
-(alias (name bench) (deps hashtbl_bench.int_replace1.10.bench hashtbl_bench.int_find1.10.bench hashtbl_bench.caml_hash.10.bench hashtbl_bench.int_replace2.10.bench hashtbl_bench.int_find2.10.bench hashtbl_bench.hashtbl_iter.100.bench hashtbl_bench.hashtbl_fold.100.bench hashtbl_bench.hashtbl_add_resizing.1000000.bench hashtbl_bench.hashtbl_add_sized.1000000.bench hashtbl_bench.hashtbl_add_duplicate.1000000.bench hashtbl_bench.hashtbl_remove.1000000.bench hashtbl_bench.hashtbl_find.1000000.bench hashtbl_bench.hashtbl_filter_map.100.bench))
+(alias (name bench) (deps hashtbl_bench.int_replace1.10.bench hashtbl_bench.int_find1.10.bench hashtbl_bench.caml_hash.10.bench hashtbl_bench.int_replace2.10.bench hashtbl_bench.int_find2.10.bench hashtbl_bench.hashtbl_iter.10.bench hashtbl_bench.hashtbl_fold.10.bench hashtbl_bench.hashtbl_add_resizing.1000000.bench hashtbl_bench.hashtbl_add_sized.1000000.bench hashtbl_bench.hashtbl_add_duplicate.1000000.bench hashtbl_bench.hashtbl_remove.1000000.bench hashtbl_bench.hashtbl_find.1000000.bench hashtbl_bench.hashtbl_filter_map.10.bench))

--- a/benchmarks/stdlib/map.inc
+++ b/benchmarks/stdlib/map.inc
@@ -1,9 +1,9 @@
 (executable (name map_bench) (modules map_bench))
 
 (rule
-         (targets map_bench.map_iter.10.bench)
+         (targets map_bench.map_iter.10000.bench)
           (deps (:prog map_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} map_iter 10)))
+           (action (run orun -o %{targets} -- %{prog} map_iter 10000)))
 (rule
          (targets map_bench.map_add.1000000.bench)
           (deps (:prog map_bench.exe))
@@ -17,20 +17,20 @@
           (deps (:prog map_bench.exe))
            (action (run orun -o %{targets} -- %{prog} map_remove 1000000)))
 (rule
-         (targets map_bench.map_fold.10.bench)
+         (targets map_bench.map_fold.10000.bench)
           (deps (:prog map_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} map_fold 10)))
+           (action (run orun -o %{targets} -- %{prog} map_fold 10000)))
 (rule
-         (targets map_bench.map_for_all.10.bench)
+         (targets map_bench.map_for_all.10000.bench)
           (deps (:prog map_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} map_for_all 10)))
+           (action (run orun -o %{targets} -- %{prog} map_for_all 10000)))
 (rule
          (targets map_bench.map_find.1000000.bench)
           (deps (:prog map_bench.exe))
            (action (run orun -o %{targets} -- %{prog} map_find 1000000)))
 (rule
-         (targets map_bench.map_map.10.bench)
+         (targets map_bench.map_map.10000.bench)
           (deps (:prog map_bench.exe))
-           (action (run orun -o %{targets} -- %{prog} map_map 10)))
+           (action (run orun -o %{targets} -- %{prog} map_map 10000)))
 
-(alias (name bench) (deps map_bench.map_iter.10.bench map_bench.map_add.1000000.bench map_bench.map_add_duplicate.1000000.bench map_bench.map_remove.1000000.bench map_bench.map_fold.10.bench map_bench.map_for_all.10.bench map_bench.map_find.1000000.bench map_bench.map_map.10.bench))
+(alias (name bench) (deps map_bench.map_iter.10000.bench map_bench.map_add.1000000.bench map_bench.map_add_duplicate.1000000.bench map_bench.map_remove.1000000.bench map_bench.map_fold.10000.bench map_bench.map_for_all.10000.bench map_bench.map_find.1000000.bench map_bench.map_map.10000.bench))

--- a/benchmarks/stdlib/pervasives.inc
+++ b/benchmarks/stdlib/pervasives.inc
@@ -25,12 +25,12 @@
               (deps (:prog pervasives_bench.exe))
                (action (run orun -o %{targets} -- %{prog} pervasives_compare_floats 100000000)))
 (rule
-             (targets pervasives_bench.pervasives_equal_strings.100000000.bench)
+             (targets pervasives_bench.pervasives_equal_strings.20000000.bench)
               (deps (:prog pervasives_bench.exe))
-               (action (run orun -o %{targets} -- %{prog} pervasives_equal_strings 100000000)))
+               (action (run orun -o %{targets} -- %{prog} pervasives_equal_strings 20000000)))
 (rule
-             (targets pervasives_bench.pervasives_compare_strings.100000000.bench)
+             (targets pervasives_bench.pervasives_compare_strings.20000000.bench)
               (deps (:prog pervasives_bench.exe))
-               (action (run orun -o %{targets} -- %{prog} pervasives_compare_strings 100000000)))
+               (action (run orun -o %{targets} -- %{prog} pervasives_compare_strings 20000000)))
 
 (alias (name bench) (deps pervasives_bench.pervasives_equal_lists.100000000.bench pervasives_bench.pervasives_compare_lists.100000000.bench pervasives_bench.pervasives_equal_ints.100000000.bench pervasives_bench.pervasives_compare_ints.100000000.bench pervasives_bench.pervasives_equal_floats.100000000.bench pervasives_bench.pervasives_compare_floats.100000000.bench pervasives_bench.pervasives_equal_strings.20000000.bench pervasives_bench.pervasives_compare_strings.20000000.bench))

--- a/benchmarks/stdlib/pervasives.inc
+++ b/benchmarks/stdlib/pervasives.inc
@@ -33,4 +33,4 @@
               (deps (:prog pervasives_bench.exe))
                (action (run orun -o %{targets} -- %{prog} pervasives_compare_strings 100000000)))
 
-(alias (name bench) (deps pervasives_bench.pervasives_equal_lists.100000000.bench pervasives_bench.pervasives_compare_lists.100000000.bench pervasives_bench.pervasives_equal_ints.100000000.bench pervasives_bench.pervasives_compare_ints.100000000.bench pervasives_bench.pervasives_equal_floats.100000000.bench pervasives_bench.pervasives_compare_floats.100000000.bench pervasives_bench.pervasives_equal_strings.100000000.bench pervasives_bench.pervasives_compare_strings.100000000.bench))
+(alias (name bench) (deps pervasives_bench.pervasives_equal_lists.100000000.bench pervasives_bench.pervasives_compare_lists.100000000.bench pervasives_bench.pervasives_equal_ints.100000000.bench pervasives_bench.pervasives_compare_ints.100000000.bench pervasives_bench.pervasives_equal_floats.100000000.bench pervasives_bench.pervasives_compare_floats.100000000.bench pervasives_bench.pervasives_equal_strings.20000000.bench pervasives_bench.pervasives_compare_strings.20000000.bench))


### PR DESCRIPTION
move the params to make the runtime a in benchmarks/stdlib more balanced.