### PR TITLE
Run perf tool in addition to default build action.

### DIFF
--- a/benchmarks/bdd/dune
+++ b/benchmarks/bdd/dune
@@ -6,6 +6,9 @@
 (rule
  (targets bdd.bench)
  (deps (:prog bdd.exe))
- (action (run orun -o %{targets} -- %{prog})))
+ (action (progn
+	(run orun -o %{targets} -- %{prog})
+	(run perf stat -ax'|' -o %{prog}.perf %{prog}))))
 
 (alias (name bench) (deps bdd.bench))
+


### PR DESCRIPTION
This is another approach of generating perf stats in addition to the default
bench stats by running 'perf' right after 'orun' during bench build rule.

Pros:
Simple and mechanical diff.
Any additions tools/generators could be concatenated to the list of actions).

Cons:
Hard coded executable and command line parameters.