### PR TITLE
Proof of concept: Bring orun out of dune rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,19 +74,13 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp setup_sys_dune
 	opam switch create --keep-build-dir --yes $* ocaml-base-compiler.$*
 	opam pin add -n --yes --switch $* orun orun/
 
-BENCH = $(shell basename $(BENCH_TARGET))
-
 .PHONY: .FORCE
 .FORCE:
 ocaml-versions/%.bench: ocaml-versions/%.comp _opam/% .FORCE
 	@opam update
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 	$(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release $(BENCH_TARGET)
-	@{ for i in `seq 1 $(ITER)`; do \
-		opam exec --switch $* -- orun -o _build/default/benchmarks/$(BENCH)/$(BENCH).$$i.bench -- \
-		_build/default/benchmarks/$(BENCH)/$(BENCH).exe; done; \
-		find _build/ -name '*.bench' | xargs cat > $@; \
-	}
+	sh run.sh $(ITER) $* $(BENCH_TARGET) orun $@
 
 clean:
 	rm -rf dependencies/packages/ocaml/*

--- a/Makefile
+++ b/Makefile
@@ -74,19 +74,19 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.comp setup_sys_dune
 	opam switch create --keep-build-dir --yes $* ocaml-base-compiler.$*
 	opam pin add -n --yes --switch $* orun orun/
 
+BENCH = $(shell basename $(BENCH_TARGET))
 
 .PHONY: .FORCE
 .FORCE:
 ocaml-versions/%.bench: ocaml-versions/%.comp _opam/% .FORCE
 	@opam update
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
-	@{ echo '(lang dune 1.0)'; \
-	   for i in `seq 1 $(ITER)`; do \
-	     echo "(context (opam (switch $*) (name $*_$$i)))"; \
-           done } > ocaml-versions/.workspace.$*
-	$(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release --workspace=ocaml-versions/.workspace.$* @$(BENCH_TARGET); \
-	  ex=$$?; find _build/$*_* -name '*.bench' | xargs cat > $@; exit $$ex
-
+	$(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release $(BENCH_TARGET)
+	@{ for i in `seq 1 $(ITER)`; do \
+		opam exec --switch $* -- orun -o _build/default/benchmarks/$(BENCH)/$(BENCH).$$i.bench -- \
+		_build/default/benchmarks/$(BENCH)/$(BENCH).exe; done; \
+		find _build/ -name '*.bench' | xargs cat > $@; \
+	}
 
 clean:
 	rm -rf dependencies/packages/ocaml/*

--- a/benchmarks/bdd/dune
+++ b/benchmarks/bdd/dune
@@ -2,10 +2,3 @@
 ;; See https://github.com/OCamlPro/ocamlbench-repo
 (executable
  (name bdd))
-
-(rule
- (targets bdd.bench)
- (deps (:prog bdd.exe))
- (action (run orun -o %{targets} -- %{prog})))
-
-(alias (name bench) (deps bdd.bench))

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# Helper script to run a given benchmark target through the
+# performance tool for given number of iterations using the OCaml
+# version provided.
+
+progname=${0##*/}
+usage()
+{
+    echo "Usage: ${progname} iterations ocaml_prefix bench_target perf_tool outfn"
+    exit 1
+}
+
+if [ $# != 5 ]; then usage; fi
+iterations=$1
+ocaml_prefix=$2
+bench_target=$3
+perf_tool=$4
+outfn=$5
+bench_path="_build/default/benchmarks"
+root=$(pwd)
+export OPAMROOT=${root}/_opam
+
+if [ ${bench_target} = "all" ]; then
+    echo "TODO: Run all benchmarks...";
+else
+    bn=$(basename ${bench_target})
+    cd ${bench_path}/${bn}
+    for i in $(seq 1 ${iterations}); do
+	opam exec --switch ${ocaml_prefix} -- \
+	     ${perf_tool} -o ${bn}.${i}.bench -- ./${bn}.exe;
+    done
+    cd ${root}
+    find _build/ -name '*.bench' | xargs cat > ${outfn}
+fi


### PR DESCRIPTION
For this diff let's consider BENCH_TARGET=benchmarks/bdd alone.

The master branch with 'make ocaml-versions/4.07.1.bench
BENCH_TARGET=benchmarks/bdd/bench' and this PR with 'make
ocaml-versions/4.07.1.bench BENCH_TARGET=benchmarks/bdd' (note just
directory without a bench target) produces similar[0] output in
ocaml-versions/4.07.1.bench.

[0] Full path of executable with this PR vs just basename with master.