### PR TITLE
Add OCAML_EVENTLOG_ENABLED=1 and OCAML_EVENTLOG_FILE

### DIFF
--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -198,6 +198,8 @@ let run output input cmdline =
     in
     let environ =
       "OCAMLRUNPARAM=v=0x400"
+      :: "OCAML_EVENTLOG_ENABLED=1" (* enable tracing on eventlog branches *)
+      :: Printf.sprintf "OCAML_EVENTLOG_FILE=%s.trace" name
       :: List.filter
            (fun s -> not (starts_with s "OCAMLRUNPARAM="))
            (Array.to_list (Unix.environment ()))


### PR DESCRIPTION
Hey,
Just as discussed on Slack, this is the hack I used to enable tracing runtime on a sandmark run.
OCAML_EVENTLOG_FILE is just for the output file name, it is not yet kept as a build artifact (because we want to improve size first).
We will just have another compiler branch to test eventlog branch but with tracing off by disabling tracing by default.