### PR TITLE
Merge orun benchmarks into a toplevel .orun.bench file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ocaml-versions/%.bench: log_sandmark_hash ocaml-versions/%.comp _opam/% .FORCE
 	   d=`basename $$f | cut -d '.' -f 1,2`; \
 	   mkdir -p _results/$*/$$d/ ; cp $$f _results/$*/$$d/; \
 	done };
-	@{ find _build/$*_* -name '*.bench' | xargs cat > _results/$*/$*.bench; };
+	@{ find _build/$*_* -name '*.orun.bench' | xargs cat > _results/$*/$*.orun.bench; };
 	exit $$ex;
 
 


### PR DESCRIPTION
 that will not collide with other .bench files. 

This proved a problem if you do a run_orun followed by run_perfstat in the same sandmark directory. 
