### PR TITLE
Add required parameter for orun

### DIFF
--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -259,7 +259,7 @@ open Cmdliner
 
 let output =
   let doc = "Output location for run statistics" in
-  Arg.(value & opt string "" & info ["o"; "output"] ~docv:"FILE" ~doc)
+  Arg.(required & value & opt string "" & info ["o"; "output"] ~docv:"FILE" ~doc)
 
 let input =
   let doc = "Optional file to use as stdin" in


### PR DESCRIPTION
The man page for orun says(doesn't mention -o FILE is required):
`        -o FILE, --output=FILE
           Output location for run statistics
`

and the orun errors out with the following error message:

`
orun: internal error, uncaught exception:
      Sys_error(": No such file or directory")
`

Adding required parameter to -o so that it fails with a more meaningful message if output file is not present.