### PR TITLE
Fix name for lexifi-g2pp config

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -313,7 +313,7 @@
     },
     {
       "executable": "benchmarks/lexifi-g2pp/main.exe",
-      "name": "main",
+      "name": "lexifi-g2pp",
       "ismacrobench": true,
       "runs": [
         {


### PR DESCRIPTION
The name for the lexifi-g2pp test is incorrectly set to 'main'.