### PR TITLE
Make response channel for multicore-numerical benchmarks have length 1

### DIFF
--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -16,7 +16,7 @@ let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let max_depth = try int_of_string Sys.argv.(2) with _ -> 10
 
 let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 0})
+  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 type 'a tree = Empty | Node of 'a tree * 'a tree
 

--- a/benchmarks/multicore-numerical/game_of_life_multicore.ml
+++ b/benchmarks/multicore-numerical/game_of_life_multicore.ml
@@ -4,15 +4,15 @@ let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let n_times = try int_of_string Sys.argv.(2) with _ -> 2
 let board_size = 1024
 
-let rg = 
+let rg =
   ref (Array.init board_size (fun _ -> Array.init board_size (fun _ -> Random.int 2)))
-let rg' = 
+let rg' =
   ref (Array.init board_size (fun _ -> Array.init board_size (fun _ -> Random.int 2)))
 let buf = Bytes.create board_size
 
 type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
-let channels = Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 0})
+let channels = Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 let get g x y =
   try g.(x).(y)
@@ -49,8 +49,8 @@ let next () =
   let g = !rg in
   let new_g = !rg' in
   let job i () =
-    evaluate g new_g 
-      (i * (board_size - 1) / num_domains) 
+    evaluate g new_g
+      (i * (board_size - 1) / num_domains)
       ((i + 1) * (board_size - 1) / num_domains)
   in
   Array.iteri (fun i c -> C.send c.req (Do (job i))) channels ;
@@ -63,7 +63,7 @@ let print g =
   for x = 0 to board_size - 1 do
     for y = 0 to board_size - 1 do
       if g.(x).(y) = 0
-      then Bytes.set buf y '.' 
+      then Bytes.set buf y '.'
       else Bytes.set buf y 'o'
     done;
     print_endline (Bytes.unsafe_to_string buf)

--- a/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
@@ -5,7 +5,7 @@ let size = try int_of_string Sys.argv.(2) with _ -> 1024
 
 type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
-let channels = Array.init (num_domains -1) (fun _ -> {req= C.make 1; resp= C.make 0})
+let channels = Array.init (num_domains -1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 let matrix_multiply z x y s e =
   (* let x0 = Array.length x  in *)

--- a/benchmarks/multicore-numerical/matrix_multiplication_tiling_multicore.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication_tiling_multicore.ml
@@ -6,7 +6,7 @@ let size = try int_of_string Sys.argv.(2) with _ -> 1024
 type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
 let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 0})
+  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 let ts=64
 

--- a/benchmarks/multicore-numerical/nbody_multicore.ml
+++ b/benchmarks/multicore-numerical/nbody_multicore.ml
@@ -17,7 +17,7 @@ let days_per_year = 365.24
 type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
 let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 0})
+  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 type planet = { mutable x : float;  mutable y : float;  mutable z : float;
                 mutable vx: float;  mutable vy: float;  mutable vz: float;

--- a/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
+++ b/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
@@ -15,7 +15,7 @@ type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
 
 let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 0})
+  Array.init (num_domains - 1) (fun _ -> {req= C.make 1; resp= C.make 1})
 
 let eval_A i j = 1. /. float (((i + j) * (i + j + 1) / 2) + i + 1)
 


### PR DESCRIPTION
This PR optimizes the multicore-numerical benchmarks such that the worker threads do not need to block on the response channel.