### PR TITLE
add gramMatrix to bench

### DIFF
--- a/benchmarks/multicore-grammatrix/dune
+++ b/benchmarks/multicore-grammatrix/dune
@@ -7,3 +7,9 @@
  (name grammatrix_multicore)
  (modules grammatrix_multicore )
  (libraries unix domainslib utls))
+
+ (alias (name multibench_parallel)
+ 			 (deps grammatrix_multicore.exe grammatrix.exe))
+
+ (alias (name buildbench)
+        (deps grammatrix.exe))

--- a/benchmarks/multicore-grammatrix/grammatrix.ml
+++ b/benchmarks/multicore-grammatrix/grammatrix.ml
@@ -42,7 +42,7 @@ let parse_line line =
     ) int_strings;
   res
 
-let input_fn = try Sys.argv.(2) with _ ->  "benchmarks/multicore-grammatrix/data/tox21_nrar_ligands_std_rand_01.csv"
+let input_fn = try Sys.argv.(2) with _ ->  "../../../../benchmarks/multicore-grammatrix/data/tox21_nrar_ligands_std_rand_01.csv"
 let ncores = try int_of_string Sys.argv.(1) with _ -> 4
 
 

--- a/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
+++ b/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
@@ -43,7 +43,7 @@ let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
 type message = Do of (unit -> unit) | Quit
 type chan = {req: message C.t; resp: unit C.t}
 let channels = Array.init (num_domains -1) (fun _ -> {req= C.make 1; resp= C.make 1})
-let input_fn = try Sys.argv.(2) with _ ->  "data/tox21_nrar_ligands_std_rand_01.csv"
+let input_fn = try Sys.argv.(2) with _ ->  "../../../../benchmarks/multicore-grammatrix/data/tox21_nrar_ligands_std_rand_01.csv"
 
 
 let compute_gram_matrix samples num_domains =


### PR DESCRIPTION
Adds gramMatrix benchmark to `multibench_parallel` and `build_bench`, fixes input file location.