### PR TITLE
Task-api port of Game of Life, Spectralnorm, Binarytree5

### DIFF
--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -57,6 +57,7 @@ let loop_depths d =
     
     loop [] 0 num_domains;
     let _ = Array.fold_left (+) 0 values in
+    ()
     (* Printf.printf "%i\t trees of depth %i\t check: %i\n" niter d sum *)
   done
 

--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -1,15 +1,8 @@
-module C = Domainslib.Chan
-
-type message = Do of (unit -> unit) | Quit
-
-type chan = {req: message C.t; resp: unit C.t}
+module T = Domainslib.Task
 
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let max_depth = try int_of_string Sys.argv.(2) with _ -> 10
-
-let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make_bounded 1; resp= C.make_bounded 1})
-
+let pool = T.setup_pool ~num_domains:(num_domains - 1)
 
 type 'a tree = Empty | Node of 'a tree * 'a tree
 
@@ -30,12 +23,14 @@ let stretch_depth = max_depth + 1
 
 let () =
   (* Gc.set { (Gc.get()) with Gc.minor_heap_size = 1024 * 1024; max_overhead = -1; }; *)
-  let c = check (make stretch_depth) in
-  Printf.printf "stretch tree of depth %i\t check: %i\n" stretch_depth c
+  let _ = check (make stretch_depth) in
+  ()
+  (* Printf.printf "stretch tree of depth %i\t check: %i\n" stretch_depth c *)
 
 let long_lived_tree = make max_depth
 
 let values = Array.make num_domains 0
+let promise_list = ref []
 
 let calculate d st en ind =
   (* Printf.printf "st = %d en = %d\n" st en; *)
@@ -43,36 +38,28 @@ let calculate d st en ind =
   for _ = st to en do
   c := !c + check (make d)
   done;
+  (* Printf.printf "ind = %d\n" ind; *)
   values.(ind) <- !c
-
-let rec worker c () =
-  match C.recv c.req with
-  | Do f ->
-      f () ; C.send c.resp () ; worker c ()
-  | Quit ->
-      ()
 
 let loop_depths d =
   for i = 0 to  ((max_depth - d) / 2 + 1) - 1 do
     let d = d + i * 2 in
     let niter = 1 lsl (max_depth - d + min_depth) in
-    let job i () = calculate d (i * niter / num_domains) (((i + 1) * niter / num_domains) - 1) i in
-    Array.iteri (fun i c -> C.send c.req (Do (job i))) channels ;
-    job (num_domains - 1) ();
-    Array.iter (fun c -> C.recv c.resp) channels;
-    let sum = Array.fold_left (+) 0 values in
+    for i = 0 to pred num_domains do
+      promise_list := (T.async pool (fun _ -> calculate d (i * niter / num_domains) (((i + 1) * niter / num_domains) - 1) i )) :: !promise_list
+    done;
 
-    (* let domains = worker d (num_domains) 1 (niter/num_domains) in
-    let sum = List.fold_left (+) 0 (List.map Domain.join domains) in *)
-    (* let sum = calculate d 1 niter in *)
-      Printf.printf "%i\t trees of depth %i\t check: %i\n" niter d sum ;
+    List.iter (fun pr -> T.await pool pr) (List.rev !promise_list);
+    
+    (* T.parallel_for pool ~chunk_size:(num_domains) ~start:0 ~finish:(num_domains - 1) ~body:(fun index -> calculate d ((index * niter) / num_domains) ((((index + 1) * niter) / num_domains) - 1) index); *)
+
+    let _sum = Array.fold_left (+) 0 values in
+    ()
+    (* Printf.printf "%i\t trees of depth %i\t check: %i\n" niter d sum *)
   done
 
 let () =
-  let domains = Array.map (fun c -> Domain.spawn (worker c)) channels in
-  flush stdout;
   loop_depths min_depth;
-  Printf.printf "long lived tree of depth %i\t check: %i\n"
-    max_depth (check long_lived_tree);
-    Array.iter (fun c -> C.send c.req Quit) channels ;
-    Array.iter Domain.join domains
+  let _ = max_depth in
+  let _ = (check long_lived_tree) in
+  T.teardown_pool pool

--- a/benchmarks/multicore-numerical/game_of_life_multicore.ml
+++ b/benchmarks/multicore-numerical/game_of_life_multicore.ml
@@ -1,18 +1,14 @@
-module C = Domainslib.Chan
-
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let n_times = try int_of_string Sys.argv.(2) with _ -> 2
-let board_size = 1024
+let board_size = try int_of_string Sys.argv.(3) with _ -> 1024
+
+module T = Domainslib.Task
 
 let rg =
   ref (Array.init board_size (fun _ -> Array.init board_size (fun _ -> Random.int 2)))
 let rg' =
   ref (Array.init board_size (fun _ -> Array.init board_size (fun _ -> Random.int 2)))
 let buf = Bytes.create board_size
-
-type message = Do of (unit -> unit) | Quit
-type chan = {req: message C.t; resp: unit C.t}
-let channels = Array.init (num_domains - 1) (fun _ -> {req= C.make_bounded 1; resp= C.make_bounded 1})
 
 let get g x y =
   try g.(x).(y)
@@ -37,29 +33,7 @@ let next_cell g x y =
   | 0, 3                             -> 1  (* get birth *)
   | _ (* 0, (0|1|2|4|5|6|7|8) *)     -> 0  (* barren *)
 
-let evaluate g new_g s e =
-  for x = s to e do
-    for y = 0 to board_size - 1 do
-      Domain.Sync.poll ();
-      new_g.(x).(y) <- next_cell g x y
-    done
-  done
-
-let next () =
-  let g = !rg in
-  let new_g = !rg' in
-  let job i () =
-    evaluate g new_g
-      (i * (board_size - 1) / num_domains)
-      ((i + 1) * (board_size - 1) / num_domains)
-  in
-  Array.iteri (fun i c -> C.send c.req (Do (job i))) channels ;
-  job (num_domains - 1) ();
-  Array.iter (fun c -> C.recv c.resp) channels;
-  rg := new_g;
-  rg' := g
-
-let print g =
+(* let print g =
   for x = 0 to board_size - 1 do
     for y = 0 to board_size - 1 do
       if g.(x).(y) = 0
@@ -68,22 +42,29 @@ let print g =
     done;
     print_endline (Bytes.unsafe_to_string buf)
   done;
-  print_endline ""
+  print_endline "" *)
 
-let rec repeat n =
+let next pool =
+  let g = !rg in
+  let new_g = !rg' in
+  T.parallel_for pool ~chunk_size:(board_size/num_domains) ~start:0
+    ~finish:(board_size - 1) ~body:(fun x ->
+      for y = 0 to board_size - 1 do
+        new_g.(x).(y) <- next_cell g x y
+      done);
+  rg := new_g;
+  rg' := g
+
+
+let rec repeat pool n =
   match n with
   | 0-> ()
-  | _-> next (); repeat (n-1)
-
-let rec worker c () =
-  match C.recv c.req with
-  | Do f -> f () ; C.send c.resp () ; worker c ()
-  | Quit -> ()
+  | _-> next pool; repeat pool (n-1)
 
 let ()=
-  let domains = Array.map (fun c -> Domain.spawn (worker c)) channels in
-  print !rg;
-  repeat n_times;
-  print !rg;
-  Array.iter (fun c -> C.send c.req Quit) channels;
-  Array.iter Domain.join domains
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  (* print !rg; *)
+  repeat pool n_times;
+  (* print !rg; *)
+  T.teardown_pool pool
+

--- a/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
+++ b/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
@@ -6,77 +6,43 @@
  * Modified by Mauricio Fernandez
  *)
 
-module C = Domainslib.Chan
-
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
-let n = try int_of_string Sys.argv.(2) with _ -> 2000
+let n = try int_of_string Sys.argv.(2) with _ ->  2000
 
-type message = Do of (unit -> unit) | Quit
-type chan = {req: message C.t; resp: unit C.t}
+module T = Domainslib.Task
 
-let channels =
-  Array.init (num_domains - 1) (fun _ -> {req= C.make_bounded 1; resp= C.make_bounded 1})
+let eval_A i j = 1. /. float((i+j)*(i+j+1)/2+i+1)
 
-let eval_A i j = 1. /. float (((i + j) * (i + j + 1) / 2) + i + 1)
-
-let eval_A_times_u u v s e =
+let eval_A_times_u pool u v =
   let n = Array.length v - 1 in
-  for i = s to e do
+  T.parallel_for pool ~start:0 ~finish:n ~chunk_size:(n/num_domains)
+    ~body:(fun i ->
+      let vi = ref 0. in
+      for j = 0 to n do vi := !vi +. eval_A i j *. u.(j) done;
+      v.(i) <- !vi)
+
+let eval_At_times_u pool u v =
+  let n = Array.length v -1 in
+  T.parallel_for pool ~start:0 ~finish:n ~chunk_size:(n/num_domains)
+    ~body:(fun i ->
     let vi = ref 0. in
-    for j = 0 to n do
-      vi := !vi +. (eval_A i j *. u.(j))
-    done ;
-    v.(i) <- !vi
-  done
+    for j = 0 to n do vi := !vi +. eval_A j i *. u.(j) done;
+    v.(i) <- !vi)
 
-let divvy_up1 u v =
-  let job i () =
-    eval_A_times_u u v (i * n / num_domains) (((i + 1) * n / num_domains) - 1)
-  in
-  Array.iteri (fun i c -> C.send c.req (Do (job i))) channels ;
-  job (num_domains - 1) ();
-  Array.iter (fun c -> C.recv c.resp) channels
-
-let eval_At_times_u u v s e =
-  let n = Array.length v - 1 in
-  for i = s to e do
-    let vi = ref 0. in
-    for j = 0 to n do
-      vi := !vi +. (eval_A j i *. u.(j))
-    done ;
-    v.(i) <- !vi
-  done
-
-let divvy_up2 u v =
-  let job i () =
-    eval_At_times_u u v (i * n / num_domains) (((i + 1) * n / num_domains) - 1)
-  in
-  Array.iteri (fun i c -> C.send c.req (Do (job i))) channels ;
-  job (num_domains - 1) ();
-  Array.iter (fun c -> C.recv c.resp) channels
-
-let eval_AtA_times_u u v =
+let eval_AtA_times_u pool u v =
   let w = Array.make (Array.length u) 0.0 in
-  divvy_up1 u w ; divvy_up2 w v
-
-let rec worker c () =
-  match C.recv c.req with
-  | Do f ->
-      f () ; C.send c.resp () ; worker c ()
-  | Quit ->
-      ()
+  eval_A_times_u pool u w; eval_At_times_u pool w v
 
 let () =
-  let domains = Array.map (fun c -> Domain.spawn (worker c)) channels in
-  let u = Array.make n 1.0 and v = Array.make n 0.0 in
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  let u = Array.make n 1.0  and  v = Array.make n 0.0 in
   for _i = 0 to 9 do
-    eval_AtA_times_u u v ; eval_AtA_times_u v u
-  done ;
-  let vv = ref 0.0 and vBv = ref 0.0 in
-  for i = 0 to n - 1 do
-    vv := !vv +. (v.(i) *. v.(i)) ;
-    vBv := !vBv +. (u.(i) *. v.(i))
-  done ;
-  Array.iter (fun c -> C.send c.req Quit) channels ;
-  Array.iter Domain.join domains ;
-  Printf.printf "%0.9f\n" (sqrt (!vBv /. !vv))
+    eval_AtA_times_u pool u v; eval_AtA_times_u pool v u
+  done;
+  T.teardown_pool pool;
+
+  let vv = ref 0.0  and  vBv = ref 0.0 in
+  for i=0 to n-1 do
+    vv := !vv +. v.(i) *. v.(i);
+    vBv := !vBv +. u.(i) *. v.(i)
+  done


### PR DESCRIPTION
Porting code of Game of Life, Spectralnorm and Binarytree5 from channels to task-api.

Game of Life (n = 256)
|  Domains | Channels | Tasks |
| --- | --- | --- |
|  1 | 45.187 | 44.37 |
|  2 | 23.105 | 22.286 |
|  4 | 11.663 | 11.201 |
|  8 | 5.952 | 5.668 |
|  12 | 4.078 | 3.976 |
|  16 | 3.102 | 2.927 |
|  20 | 2.534 | 2.513 |
|  24 | 2.165 | 2.67 |


Spectralnorm (n = 5500)
|  Domains | Channels | Tasks |
| --- | --- | --- |
|  1 | 7.822 | 8.358 |
|  2 | 3.929 | 4.201 |
|  4 | 1.974 | 2.116 |
|  8 | 1 | 1.071 |
|  12 | 0.683 | 0.732 |
|  16 | 0.526 | 0.562 |
|  20 | 0.431 | 0.476 |
|  24 | 0.369 | 0.393 |


Binarytree5 (n = 23)
|  Domains | Channels | Tasks |
| --- | --- | --- |
|  1 | 69.313 | 71.728 |
|  2 | 42.267 | 41.823 |
|  4 | 24.72 | 23.123 |
|  8 | 13.488 | 12.56 |
|  12 | 12.38 | 11.265 |
|  16 | 11.182 | 10.452 |
|  20 | 10.358 | 8.84 |
|  24 | 9.809 | 8.751 |