### PR TITLE
Use --format=columns with pip3 list in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ endef
 
 depend:
 	$(foreach d, $(DEPENDENCIES),     $(call check_dependency, $(d), dpkg -l,   Install on Ubuntu using apt.))
-	$(foreach d, $(PIP_DEPENDENCIES), $(call check_dependency, $(d), pip3 list, Install using pip3 install.))
+	$(foreach d, $(PIP_DEPENDENCIES), $(call check_dependency, $(d), pip3 list --format=columns, Install using pip3 install.))
 
 clean:
 	rm -rf dependencies/packages/ocaml/*


### PR DESCRIPTION
The PR enforces the use of `--format=columns` with `pip3 list` to handle the following warning: 
```
"DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning."
```