### PR TITLE
Reflect ocaml-multicore repo branch changes

### DIFF
--- a/ocaml-versions/4.06.1+multicore+stw+parallel.comp
+++ b/ocaml-versions/4.06.1+multicore+stw+parallel.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_06.tar.gz

--- a/ocaml-versions/4.06.1+multicore+stw+pausetimes+parallel.comp
+++ b/ocaml-versions/4.06.1+multicore+stw+pausetimes+parallel.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_06.tar.gz

--- a/ocaml-versions/4.06.1+multicore+stw+pausetimes.comp
+++ b/ocaml-versions/4.06.1+multicore+stw+pausetimes.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_06.tar.gz

--- a/ocaml-versions/4.06.1+multicore+stw.comp
+++ b/ocaml-versions/4.06.1+multicore+stw.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_06.tar.gz

--- a/ocaml-versions/4.10.0+multicore+parallel.comp
+++ b/ocaml-versions/4.10.0+multicore+parallel.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_10.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz

--- a/ocaml-versions/4.10.0+multicore+pausetimes+parallel.comp
+++ b/ocaml-versions/4.10.0+multicore+pausetimes+parallel.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_10.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz

--- a/ocaml-versions/4.10.0+multicore+pausetimes.comp
+++ b/ocaml-versions/4.10.0+multicore+pausetimes.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_10.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz

--- a/ocaml-versions/4.10.0+multicore.comp
+++ b/ocaml-versions/4.10.0+multicore.comp
@@ -1,1 +1,1 @@
-https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc_4_10.tar.gz
+https://github.com/ocaml-multicore/ocaml-multicore/archive/parallel_minor_gc.tar.gz


### PR DESCRIPTION
This PR updates the multicore `ocaml-version/*.comp` files to reflect the new ocaml-multicore naming.