### PR TITLE
Use BUILD_ONLY in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,9 +16,7 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - wget https://github.com/ocaml-bench/sandmark/pull/131.patch
-  - patch -p1 < 131.patch
-  - DRY_RUN=1 make ocaml-versions/4.10.0+stock.bench
+  - BUILD_ONLY=1 make ocaml-versions/4.10.0+stock.bench
 
 ---
 kind: pipeline
@@ -39,9 +37,7 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - wget https://github.com/ocaml-bench/sandmark/pull/131.patch
-  - patch -p1 < 131.patch
-  - DRY_RUN=1 make ocaml-versions/4.10.0+multicore.bench
+  - BUILD_ONLY=1 make ocaml-versions/4.10.0+multicore.bench
 
 ---
 kind: pipeline
@@ -62,7 +58,5 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - wget https://github.com/ocaml-bench/sandmark/pull/131.patch
-  - patch -p1 < 131.patch
   - make multicore_parallel_run_config_macro_parallel.json
-  - DRY_RUN=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_macro_parallel.json make ocaml-versions/4.10.0+multicore.bench
+  - BUILD_ONLY=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_macro_parallel.json make ocaml-versions/4.10.0+multicore.bench

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RUN_CONFIG_JSON ?= run_config.json
 RUN_BENCH_TARGET ?= run_orun
 
 # Dry run test without executing benchmarks
-DRY_RUN ?= 0
+BUILD_ONLY ?= 0
 
 # number of benchmark iterations to run
 ITER ?= 1
@@ -123,7 +123,7 @@ ocaml-versions/%.bench: depend log_sandmark_hash ocaml-versions/%.comp _opam/% .
 	opam exec --switch $* -- cp pausetimes/* $$(opam config var bin)
 	opam exec --switch $* -- rungen _build/$*_1 $(RUN_CONFIG_JSON) > runs_dune.inc;
 	opam exec --switch $* -- dune build --profile=release --workspace=ocaml-versions/.workspace.$* @$(BUILD_BENCH_TARGET);
-	@{ if [ "$(DRY_RUN)" -eq 0 ]; then												\
+	@{ if [ "$(BUILD_ONLY)" -eq 0 ]; then												\
 		IS_PARALLEL=`grep -c chrt $(RUN_CONFIG_JSON)`; 										\
 		if [ "$$IS_PARALLEL" -gt 0 ]; then											\
 		  $(PRE_BENCH_EXEC) sudo -s OPAMROOT="${OPAMROOT}" OPAMROOTISOK="true" BUILD_BENCH_TARGET="${BUILD_BENCH_TARGET}" 	\


### PR DESCRIPTION
1. The PRs #131 and #132 are mutually dependent on each other, and the .drone.yml file was updated to pull the patch from #131 to #132 for the CI. Since, the PRs have been merged, we can now undo the change. 
2. Also, we now use `BUILD_ONLY` in the Makefile and .drone.yml.