### PR TITLE
Install python3-pip and intervaltree for clean CI build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,8 @@ steps:
 - name: 4.10.0+stock
   image: ocurrent/opam:ubuntu-18.04-ocaml-4.10
   commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev && sudo apt-get -y install jq
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
+  - pip3 install intervaltree
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
@@ -31,7 +32,8 @@ steps:
 - name: 4.10.0+multicore+serial
   image: ocurrent/opam:ubuntu-18.04-ocaml-4.10
   commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev && sudo apt-get -y install jq
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
+  - pip3 install intervaltree
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
@@ -53,7 +55,8 @@ steps:
 - name: 4.10.0+multicore+parallel
   image: ocurrent/opam:ubuntu-18.04-ocaml-4.10
   commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev && sudo apt-get -y install jq
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
+  - pip3 install intervaltree
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update


### PR DESCRIPTION
This PR does the following clean ups in .drone.yml:
* Add `python3-pip` as part of the apt-get install step
* Use a single 'apt-get install` command
* Invoke `pip3` to install intervaltree to avoid errors when Makefile is invoked