### PR TITLE
evolutionary algorithm - parallel benchmark

### DIFF
--- a/benchmarks/multicore-numerical/dune
+++ b/benchmarks/multicore-numerical/dune
@@ -86,6 +86,11 @@
  (name mergesort)
  (modules mergesort))
 
+(executable
+ (name evolutionary_algorithm_multicore)
+ (modules evolutionary_algorithm_multicore)
+ (libraries domainslib))
+
 (alias (name multibench_parallel)
 			 (deps mandelbrot6_multicore.exe spectralnorm2_multicore.exe quicksort.exe
 						 quicksort_multicore.exe binarytrees5_multicore.exe
@@ -94,7 +99,8 @@
 						 matrix_multiplication_tiling_multicore.exe nbody.exe
 						 nbody_multicore.exe mergesort.exe mergesort_multicore.exe
 						 floyd_warshall.exe floyd_warshall_multicore.exe
-						 LU_decomposition.exe LU_decomposition_multicore.exe))
+						 LU_decomposition.exe LU_decomposition_multicore.exe
+             evolutionary_algorithm_multicore.exe))
 
 (alias (name buildbench)
        (deps game_of_life.exe matrix_multiplication.exe quicksort.exe

--- a/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
+++ b/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
@@ -1,0 +1,120 @@
+let doc =
+"
+A minimal multicore OCaml implementation of an Evolutionary Algorithm.
+Per Kristian Lehre <p.k.lehre@cs.bham.ac.uk>
+May 6th, 2020
+"
+module T = Domainslib.Task
+let my_key : Random.State.t Domain.DLS.key = Domain.DLS.new_key ()
+
+let get () = try Option.get @@ Domain.DLS.get my_key
+  with _ -> begin
+    Domain.DLS.set my_key (Random.State.make_self_init ());
+    Option.get @@ Domain.DLS.get my_key
+  end
+
+type bitstring = bool array
+type individual = { chromosome : bitstring; fitness : float }
+type fitness_function = bitstring -> float
+type population = individual array
+
+let chromosome_length = Array.length
+let population_size = Array.length
+
+let chromosome { chromosome=x; fitness=_ } = x
+let evaluate f x = { chromosome=x; fitness=(f x) }
+
+let fittest x y = if x.fitness > y.fitness then x else y
+let pop_fittest pop = Array.fold_left fittest pop.(0) pop
+
+let random_bitstring n =
+  let s = get () in
+  Array.init n (fun _ -> Random.State.bool s)
+
+let random_individual n f =
+  evaluate f (random_bitstring n)
+
+(* Onemax is a simple fitness function. *)
+let add_bit x b = if b then x +. 1.0 else x
+let onemax : fitness_function = Array.fold_left add_bit 0.0
+
+(* Choose fittest out of k uniformly sampled individuals *)
+let rec k_tournament k pop =
+  let s = Option.get @@ Domain.DLS.get my_key in
+  let x = pop.(Random.State.int s (population_size pop)) in
+  if k <= 1 then x
+  else
+    let y = k_tournament (k-1) pop in
+    fittest x y
+
+let flip_coin p =
+  let s = Option.get @@ Domain.DLS.get my_key in
+  (Random.State.float s 1.0) < p
+
+let xor a b = if a then not b else b
+(* Naive Theta(n) implementation of mutation. *)
+let mutate chi x =
+  let n = chromosome_length x in
+  let p = chi /. (float n) in
+  Array.map (fun b -> xor b (flip_coin p)) x
+
+(* Command line arguments *)
+
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
+
+let runtime = 100000
+
+let chi = 0.4
+
+let lambda = try int_of_string Sys.argv.(3) with _ -> 1000
+
+let k = 2
+
+let n = try int_of_string Sys.argv.(2) with _ -> 1000
+  
+let multicore_init pool num_domains x0 n f =
+  let a = Array.make n x0 in
+  T.parallel_for
+    pool ~chunk_size:(n/num_domains) ~start:0 ~finish:(n-1)
+    ~body:(fun i -> a.(i) <- f ());
+  a
+
+let evolutionary_algorithm
+
+    num_domains   (* Number of multicore domains *)
+    runtime       (* Runtime budget  *)
+    lambda        (* Population size *)
+    k             (* Tournament size *)
+    chi           (* Mutation rate   *)
+    fitness       (* Fitness function *)
+    n             (* Problem instance size n *)
+
+  =
+
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  let adam = random_individual n fitness in
+  let init_pop = multicore_init pool num_domains adam in
+  let pop0 = init_pop lambda (fun _ -> random_individual n fitness) in
+
+
+  let rec generation time pop =
+    let next_pop =
+      init_pop lambda
+	(fun _ ->
+             (k_tournament k pop)
+          |> chromosome
+          |> (mutate chi)
+          |> (evaluate fitness))
+    in
+    if time * lambda > runtime then
+      (T.teardown_pool pool;
+       Printf.printf "fittest: %f, num_domains: %d\n"
+         (pop_fittest next_pop).fitness num_domains)
+    else
+      generation (time+1) next_pop
+  in generation 0 pop0
+
+let ea () = evolutionary_algorithm num_domains runtime lambda k chi onemax n
+
+let () =
+  ea ()

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -300,6 +300,21 @@
         { "params": "24 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
       ]
     },
+    {
+      "executable": "benchmarks/multicore-numerical/evolutionary_algorithm_multicore.exe",
+      "name": "evolutionary_algorithm_multicore",
+      "tags": ["macro_bench"],
+      "runs": [
+        { "params": "1 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
+        { "params": "2 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
+        { "params": "4 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
+        { "params": "8 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
+        { "params": "12 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
+        { "params": "16 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
+        { "params": "20 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
+        { "params": "24 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+      ]
+    },
 
     {
       "executable": "benchmarks/decompress/test_decompress.exe",


### PR DESCRIPTION
This PR adds a parallel benchmark posted in https://github.com/ocaml-multicore/ocaml-multicore/issues/336. 

Its performance numbers for `lambda = 10000, n = 10000`are below: 


Cores | Time(s) | Speedup
-- | -- | --
1 | 93.25 | 1
2 | 50.76 | 1.837076438
4 | 26.42 | 3.529523089
8 | 13.6 | 6.856617647
12 | 8.82 | 10.57256236
16 | 7.31 | 12.75649795
20 | 6.35 | 14.68503937
24 | 5.48 | 17.01642336
