### PR TITLE
revert paramwrapper changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ bash:
 	@echo "[opam subshell completed]"
 
 %_macro.json: %.json
-	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.ismacrobench == true)]}' < $< > $@
+	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index("macro_bench") != null)]}' < $< > $@
 
 %_macro_2domains.json: %_macro.json
 	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index("macro_bench") != null)]} | {wrappers : .wrappers, benchmarks : [.benchmarks | .[] | select(.tags | index("macro_bench") != null) | {executable : .executable, name: .name, tags: .tags, runs : [.runs | .[] as $$item | if ($$item | .params | split(" ") | .[0] ) == "2" then $$item | .paramwrapper |= "" else empty end ] } ]}' < $< > $@

--- a/README.md
+++ b/README.md
@@ -263,19 +263,3 @@ sed. `sed` will default to a BSD sed on OS X. One way to make things
 work on OS X is to install GNU sed with homebrew and then update the
 `PATH` you run sandmark with to pick up the GNU version.
 
-## User configurable benchmark wrapper
-
-To run a macro benchmark with a custom range of processors/isolated CPUs/ a conditional string can be passed with `PARAMWRAPPER`.
-
-For example :
-```bash
-$ make multicore_parallel_run_config_macro.json PARAMWRAPPER="if params < 16 then paramwrapper = 2-15 else paramwrapper = 2-15,16-21"
-```
-In the above example strings : `16`, `2-15`, `2-15,16-21` are used to construct a json file containing a `paramwrapper` record with the value : `taskset --cpu-list 2-15 chrt -r 1` or `taskset --cpu-list 2-15,16-21 chrt -r 1`. The `paramwrapper` value switches to one or the other depending on the value `params` is being compared to in this case `16`.
-
-The command above generates a new `.json` file. In this example it is `run_config_macro.json`.
-
-If no optional string is provided it defaults to
-```bash
-PARAMWRAPPER="if params < 16 then paramwrapper = 2-15 else paramwrapper = 2-15,16-27"
-```


### PR DESCRIPTION
PR to revert changes in the present in #124 because of the following reasons.


> The PARAMWRAPPER is configured for parallel benchmarks, so while generating run_config_macro.json
> - It overwrites some parameters already configured, making the runs empty. So most of the benchmarks are not being executed in a run.
> - The paramwrapper has the taskset and chrt which is meant for parallel benchmarks and not necessary for sequential benchmarks.
