### PR TITLE
Fix calculation of nbody_multicore

### DIFF
--- a/benchmarks/multicore-numerical/nbody.ml
+++ b/benchmarks/multicore-numerical/nbody.ml
@@ -29,10 +29,6 @@ let advance bodies dt =
         b.vx <- b.vx -. dx *. b'.mass *. mag;
         b.vy <- b.vy -. dy *. b'.mass *. mag;
         b.vz <- b.vz -. dz *. b'.mass *. mag;
-
-        b'.vx <- b'.vx +. dx *. b.mass *. mag;
-        b'.vy <- b'.vy +. dy *. b.mass *. mag;
-        b'.vz <- b'.vz +. dz *. b.mass *. mag;
       end
     done
   done;


### PR DESCRIPTION
This PR fixes the calculation of the interactions of the bodies and introduce local ref var for velocities to reduce writes and cache traffic.

Given that the inner loop is iterating over all `j  = 0 to Array.length bodies - 1` we should not update the `b'` velocities; updating these velocities is also not parallel domain safe. 

This PR also cuts the false sharing caused by the mutable writes by introducing local reference variables. 
A quick run with `nbody_multicore.exe 16 512 2048` gave:
 - no ref vars: ~1.87s
 - with ref vars: ~1.32s
