### PR TITLE
fix for key error in the python notebook for grammatrix

### DIFF
--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -344,7 +344,7 @@
       "name": "grammatrix",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
       ]
     },
     {


### PR DESCRIPTION
The fix solves the issue of a `Key Error` while running the python notebook in `notebooks/parallel/parallel.ipynb`

The problem was the empty `params` in the serial benchmark of the grammatrix which generated `grammatrix.` as the key instead of `grammatrix.16`