### PR TITLE
Specify prefix,libdir for alt-ergo sandbox builds

### DIFF
--- a/dependencies/packages/alt-ergo-lib/alt-ergo-lib.2.3.2/opam
+++ b/dependencies/packages/alt-ergo-lib/alt-ergo-lib.2.3.2/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["./configure" "--prefix=$OPAM_SWITCH_PREFIX" "--libdir=$CAML_LD_LIBRARY_PATH" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/dependencies/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.2/opam
+++ b/dependencies/packages/alt-ergo-parsers/alt-ergo-parsers.2.3.2/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["./configure" "--prefix=$OPAM_SWITCH_PREFIX" "--libdir=$CAML_LD_LIBRARY_PATH" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/dependencies/packages/alt-ergo/alt-ergo.2.3.2/opam
+++ b/dependencies/packages/alt-ergo/alt-ergo.2.3.2/opam
@@ -5,7 +5,7 @@ authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "OCamlPro Non-Commercial Purpose License, version 1"
 build: [
-  ["./configure" name]
+  ["./configure" "--prefix=$OPAM_SWITCH_PREFIX" "--libdir=$CAML_LD_LIBRARY_PATH" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
The `alt-ergo` library and parser fails to build in a sandbox environment. As discussed in https://github.com/OCamlPro/alt-ergo/issues/351, we need to pass the `prefix`, and `libdir` to the `configure` script in order to build the package when using a different _opam directory.