### PR TITLE
upgrade domainslib from 0.2.0 to 0.2.1

### DIFF
--- a/dependencies/packages/domainslib/domainslib.0.2.1/opam
+++ b/dependencies/packages/domainslib/domainslib.0.2.1/opam
@@ -17,6 +17,8 @@ build: [
   "dune" "build" "-p" name
 ]
 url {
-  src: "https://github.com/ocaml-multicore/domainslib/archive/0.2.0.tar.gz"
-  checksum: "md5=1b86c64551275299aff5e505ada03e8d"
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.2.1.tar.gz"
+  checksum: "md5=6edd612052aca29bec81304e28540637"
 }
+
+


### PR DESCRIPTION
This PR upgrades domainslib from 0.2.0 to 0.2.1, which will pick up the non-allocating receive poll:
https://github.com/ocaml-multicore/domainslib/releases/tag/0.2.1.