### PR TITLE
Add codesize attribute to .bench in orun

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A benchmarking suite for OCaml.
 On Ubuntu 18.04.4 LTS you can try the following commands:
 
 ```bash
-$ sudo apt-get install curl git libgmp-dev libdw-dev python3-pip jq bubblewrap m4 unzip
+$ sudo apt-get install curl git libgmp-dev libdw-dev python3-pip jq bubblewrap \
+	pkg-config m4 unzip
 $ pip3 install jupyter seaborn pandas intervaltree
 
 # Install OPAM if not available already

--- a/orun/dune
+++ b/orun/dune
@@ -12,7 +12,7 @@
 (executable
  (name orun)
  (public_name orun)
- (libraries str cmdliner yojson unix wait4 profiler))
+ (libraries base stdio re str cmdliner yojson unix wait4 profiler))
 
 (rule
  (targets profiler_library_flags.sexp)

--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -184,25 +184,22 @@ let get_benchmark_exe cmdline =
 
 let get_codesize cmdline =
   let file = get_benchmark_exe cmdline in
-  match file with
-  | "" -> 0.0
-  | _ ->
-    let command = Base.String.concat ~sep:" " ["/usr/bin/nm"; "--format=bsd";
+  let command = Base.String.concat ~sep:" " ["/usr/bin/nm"; "--format=bsd";
                                             "--debug-syms"; "--radix=d";
                                             "--print-size"; file] in
-    let lines = read_process_lines command in
-    Base.List.fold lines ~init:0 ~f:(fun total line ->
-      if not (Base.String.is_prefix ~prefix:" " line)
-       then (
-         match Base.String.split ~on:' ' line with
-         | [ _sym_addr; sym_size; (("t" | "T") as _sym_type); sym_name ]
-           when is_interesting_symbol sym_name ->
-           (match total + Base.Int.of_string sym_size with
-            | exception Failure _ -> total
-            | v -> v)
-         | _ -> total)
-       else total)
-     |> Float.of_int
+  let lines = read_process_lines command in
+  Base.List.fold lines ~init:0 ~f:(fun total line ->
+    if not (Base.String.is_prefix ~prefix:" " line)
+     then (
+       match Base.String.split ~on:' ' line with
+       | [ _sym_addr; sym_size; (("t" | "T") as _sym_type); sym_name ]
+         when is_interesting_symbol sym_name ->
+         (match total + Base.Int.of_string sym_size with
+          | exception Failure _ -> total
+          | v -> v)
+       | _ -> total)
+     else total)
+   |> Float.of_int
 
 let run output input cmdline =
   let prog = List.hd cmdline in

--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -176,14 +176,10 @@ List.rev !lines
 let get_benchmark_exe cmdline =
   let cwd = Sys.getcwd () in
   let prefix = Sys.getenv ("OPAM_SWITCH_PREFIX") in
-  let exe = List.nth cmdline 3 in
-  let final_exe = "" in
-  let result = try Str.search_forward (Str.regexp "\\.exe$") exe 0 with
-    Not_found -> 0
-  | _ -> 1 in
+  let result = List.filter (fun s -> Filename.check_suffix s ".exe") cmdline in
   match result with
-  | 0 -> Base.String.concat ~sep:"/" [prefix; "bin"; exe]
-  | _ -> let e = Str.replace_first (Str.regexp "^./") "" exe in
+  | [] -> Base.String.concat ~sep:"/" [prefix; "bin"; List.nth cmdline 3]
+  | _ -> let e = Str.replace_first (Str.regexp "^./") "" (List.hd result) in
          Base.String.concat ~sep:"/" [cwd; e]
 
 let get_codesize cmdline =

--- a/orun/orun.ml
+++ b/orun/orun.ml
@@ -153,6 +153,59 @@ let gc_stats stderr_file =
   in
   `Assoc (go false)
 
+let re = Re.Perl.compile_pat "caml[A-Z].*"
+
+let is_interesting_symbol name =
+  Base.List.exists [ "caml_curry"; "caml_tuplify"; "caml_apply" ]
+    ~f:(fun prefix -> Base.String.is_prefix ~prefix name)
+    || ( Re.execp re name
+     && not (Base.String.is_prefix ~prefix:"camlCompiler_bench_runtime" name))
+
+let read_process_lines command =
+  let lines = ref [] in
+  let in_channel = Unix.open_process_in command in
+  begin
+    try
+      while true do
+        lines := Stdio.In_channel.input_line_exn in_channel :: !lines
+      done;
+    with End_of_file ->
+      ignore (Unix.close_process_in in_channel)
+  end;
+List.rev !lines
+
+let get_benchmark_exe output cmdline =
+  let cwd = Sys.getcwd () in
+  let re_exe = Re.Perl.compile_pat ".exe$|setrip|cpdf|minilight-ocaml|frama-c|js_of_ocaml|alt-ergo|menhir|cubicle|coqc" in
+  let bench = List.find_opt (Re.execp re_exe) cmdline in
+  match bench with
+  | None -> ""
+  | Some x ->
+     let exe = Str.replace_first (Str.regexp "^./") "" x in
+     Base.String.concat ~sep:"/" [cwd; exe]
+
+let get_codesize output cmdline =
+  let file = get_benchmark_exe output cmdline in
+  match file with
+  | "" -> 0.0
+  | _ ->
+    let command = Base.String.concat ~sep:" " ["/usr/bin/nm"; "--format=bsd";
+                                            "--debug-syms"; "--radix=d";
+                                            "--print-size"; file] in
+    let lines = read_process_lines command in
+    Base.List.fold lines ~init:0 ~f:(fun total line ->
+      if not (Base.String.is_prefix ~prefix:" " line)
+       then (
+         match Base.String.split ~on:' ' line with
+         | [ _sym_addr; sym_size; (("t" | "T") as _sym_type); sym_name ]
+           when is_interesting_symbol sym_name ->
+           (match total + Base.Int.of_string sym_size with
+            | exception Failure _ -> total
+            | v -> v)
+         | _ -> total)
+       else total)
+     |> Float.of_int
+
 let run output input cmdline =
   let prog = List.hd cmdline in
   (* workaround for the lack of execve *)
@@ -203,11 +256,11 @@ let run output input cmdline =
     in
     let name = strip_suffix (Filename.basename output) ".bench" in
     let name = strip_suffix name ".orun" in
-    let ocamlrunparam = 
-      let params = 
-        match List.filter 
-                (fun s -> starts_with "OCAMLRUNPARAM=" s) 
-                (Array.to_list (Unix.environment ())) 
+    let ocamlrunparam =
+      let params =
+        match List.filter
+                (fun s -> starts_with "OCAMLRUNPARAM=" s)
+                (Array.to_list (Unix.environment ()))
         with
         | [] -> "v=0x400" (* print stats at termination *)
         | x::_ ->
@@ -245,6 +298,7 @@ let run output input cmdline =
           assert false
     in
     let after = Unix.gettimeofday () in
+    let codesize = get_codesize output cmdline in
     let stats =
       [ ("name", `String name)
       ; ("command", `String (quote_cmd cmdline))
@@ -253,7 +307,8 @@ let run output input cmdline =
       ; ("sys_time_secs", `Float sys_secs)
       ; ("maxrss_kB", `Int maxrss_kB)
       ; ("ocaml", get_ocaml_config ())
-      ; ("gc", gc_stats captured_stderr_filename) ]
+      ; ("gc", gc_stats captured_stderr_filename)
+      ; ("codesize", `Float codesize)]
     in
     let extra_config =
       Unix.environment () |> Array.to_list

--- a/orun/orun.opam
+++ b/orun/orun.opam
@@ -5,7 +5,7 @@ synopsis: "Run benchmarks and measure performance"
 maintainer: "Stephen Dolan <stephen.dolan@cl.cam.ac.uk>"
 authors: "Stephen Dolan <stephen.dolan@cl.cam.ac.uk>"
 license: "MIT"
-depends: [ "ocaml" "cmdliner" "yojson" ]
+depends: [ "ocaml" "base" "stdio" "re" "cmdliner" "yojson" ]
 build: [
   ["ocaml-update-c" "wait4.c"] {ocaml:update-c}
   ["dune" "build" "-p" name]

--- a/orun/profiler.ml
+++ b/orun/profiler.ml
@@ -100,7 +100,7 @@ module StringMap = Map.Make (String)
 module IntMap = Map.Make (struct
   type t = int
 
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end)
 
 let slash_regex = Str.regexp "[/\\.]"


### PR DESCRIPTION
The following PR is useful for `flambda` developers who are interested in the codesize (count of CAML symbols) for a benchmark as mentioned in https://github.com/ocaml-bench/sandmark/issues/122.
- [x] A new attribute `codesize` is added to each benchmark file that is a statically compiled .exe file. For example:
```
{"name":"knucleotide.", ... ,"codesize":276859.0, ...}
```
- [x] For benchmarks that execute a system binary (cpdf, setrip, cpdf, coqc, menhir etc.) with input files, use the binary from OPAM installed location..
- [x] Remove check for `camlCompiler_bench_runtime`.

Some observed benchmark results (Code Size count):
* alt-ergo     ( 2_822_040  )
* coqc          ( 5_869_305  )
* cpdf           ( 1_131_376  )
* nbody.exe       ( 276_710 )
* stress.exe         ( 84_061 )
* fft.exe               ( 38_914 )
