### PR TITLE
Addition of nqueens benchmark to multicore-numerical

### DIFF
--- a/benchmarks/multicore-numerical/dune
+++ b/benchmarks/multicore-numerical/dune
@@ -78,6 +78,15 @@
  (libraries domainslib))
 
 (executable
+ (name nqueens)
+ (modules nqueens))
+
+(executable
+ (name nqueens_multicore)
+ (modules nqueens_multicore)
+ (libraries domainslib))
+
+(executable
  (name mergesort_multicore)
  (modules mergesort_multicore)
  (libraries domainslib))
@@ -95,20 +104,22 @@
  (modules evolutionary_algorithm_multicore)
  (libraries domainslib))
 
-(alias 
+(alias
   (name multibench_parallel)
   (deps mandelbrot6_multicore.exe spectralnorm2_multicore.exe quicksort.exe
         quicksort_multicore.exe binarytrees5_multicore.exe
 	game_of_life.exe game_of_life_multicore.exe
 	matrix_multiplication.exe matrix_multiplication_multicore.exe
 	matrix_multiplication_tiling_multicore.exe nbody.exe
-	nbody_multicore.exe mergesort.exe mergesort_multicore.exe
+	nbody_multicore.exe
+  nqueens.exe nqueens_multicore.exe
+  mergesort.exe mergesort_multicore.exe
 	floyd_warshall.exe floyd_warshall_multicore.exe
 	LU_decomposition.exe LU_decomposition_multicore.exe
         evolutionary_algorithm_multicore.exe evolutionary_algorithm.exe))
 
-(alias 
+(alias
   (name buildbench)
   (deps game_of_life.exe matrix_multiplication.exe quicksort.exe
         mergesort.exe floyd_warshall.exe LU_decomposition.exe
-        evolutionary_algorithm.exe))
+        evolutionary_algorithm.exe nqueens.exe))

--- a/benchmarks/multicore-numerical/nqueens.ml
+++ b/benchmarks/multicore-numerical/nqueens.ml
@@ -1,0 +1,42 @@
+(*
+ * nqueen  4 = 2
+ * nqueen  5 = 10
+ * nqueen  6 = 4
+ * nqueen  7 = 40
+ * nqueen  8 = 92
+ * nqueen  9 = 352
+ * nqueen 10 = 724
+ * nqueen 11 = 2680
+ * nqueen 12 = 14200
+ * nqueen 13 = 73712
+ * nqueen 14 = 365596
+ * nqueen 15 = 2279184
+*)
+
+(* xs contains an array of queen positions
+ * i, j, k are the positions which conflict for the next element in xs
+ * return true if none of the queens conflict and return false otherwise
+ *)
+let rec ok i j k xs =
+  match xs with
+    | [] -> true
+    | h::t -> h<>i && h<>j && h<>k && ok i (j+1) (k-1) t
+
+let rec nqueens n j xs =
+  match n with
+  | n when n = j -> 1
+  | _ -> begin
+      let count = ref 0 in
+      for i = 0 to n-1 do
+        if ok i (i+1) (i-1) xs then
+          count := !count + (nqueens n (j+1) (i::xs))
+      done;
+      !count
+    end
+
+let board_size = try int_of_string Sys.argv.(1) with _ -> 13
+
+let () =
+  let n_solutions = nqueens board_size 0 [] in
+  Printf.printf "%i solutions for board of size %i\n" n_solutions board_size
+

--- a/benchmarks/multicore-numerical/nqueens_multicore.ml
+++ b/benchmarks/multicore-numerical/nqueens_multicore.ml
@@ -45,7 +45,7 @@ let num_domains = try int_of_string Sys.argv.(1) with _ -> 2
 let board_size = try int_of_string Sys.argv.(2) with _ -> 13
 
 let () =
-  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let n_solutions = nqueens pool board_size 0 [] in
   T.teardown_pool pool;
 

--- a/benchmarks/multicore-numerical/nqueens_multicore.ml
+++ b/benchmarks/multicore-numerical/nqueens_multicore.ml
@@ -1,0 +1,52 @@
+
+module T = Domainslib.Task
+
+(*
+ * nqueen  4 = 2
+ * nqueen  5 = 10
+ * nqueen  6 = 4
+ * nqueen  7 = 40
+ * nqueen  8 = 92
+ * nqueen  9 = 352
+ * nqueen 10 = 724
+ * nqueen 11 = 2680
+ * nqueen 12 = 14200
+ * nqueen 13 = 73712
+ * nqueen 14 = 365596
+ * nqueen 15 = 2279184
+*)
+
+(* xs contains an array of queen positions
+ * i, j, k are the positions which conflict for the next element in xs
+ * return true if none of the queens conflict and return false otherwise
+ *)
+let rec ok i j k xs =
+  match xs with
+    | [] -> true
+    | h::t -> h<>i && h<>j && h<>k && ok i (j+1) (k-1) t
+
+let rec nqueens pool n j xs =
+  match n with
+  | n when n = j -> 1
+  | _ -> begin
+      let rec enqueue i ps =
+        if i == n then ps
+        else if ok i (i+1) (i-1) xs then
+          let ps = (T.async pool (fun _ -> nqueens pool n (j+1) (i::xs)))::ps in
+          enqueue (i+1) ps
+        else
+          enqueue (i+1) ps
+        in
+      let ps = enqueue 0 [] in
+      List.fold_left (fun acc p -> acc + (T.await pool p)) 0 ps
+    end
+
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 2
+let board_size = try int_of_string Sys.argv.(2) with _ -> 13
+
+let () =
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  let n_solutions = nqueens pool board_size 0 [] in
+  T.teardown_pool pool;
+
+  Printf.printf "%i solutions for board of size %i\n" n_solutions board_size

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -172,6 +172,30 @@
     },
 
     {
+      "executable": "benchmarks/multicore-numerical/nqueens.exe",
+      "name": "nqueens",
+      "tags": ["10s_100s", "macro_bench"],
+      "runs": [
+        { "params": "15", "paramwrapper": "taskset --cpu-list 2-13" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-numerical/nqueens_multicore.exe",
+      "name": "nqueens_multicore",
+      "tags": ["macro_bench","10s_100s"],
+      "runs": [
+        { "params": "1 15", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 15", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 15", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 15", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 15", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 15", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 15", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 15", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+      ]
+    },
+
+    {
       "executable": "benchmarks/multicore-numerical/quicksort.exe",
       "name": "quicksort",
       "tags": ["1s_10s"],

--- a/run_config.json
+++ b/run_config.json
@@ -278,6 +278,20 @@
       ]
     },
     {
+      "executable": "benchmarks/multicore-numerical/nqueens.exe",
+      "name": "nqueens",
+      "tags": [
+        "1s_10s",
+        "macro_bench"
+      ],
+      "runs": [
+        {
+          "params": "14"
+        }
+      ]
+    },
+
+    {
       "executable": "benchmarks/multicore-grammatrix/grammatrix.exe",
       "name": "grammatrix",
       "tags": [


### PR DESCRIPTION
This PR adds the (classical) nqueens benchmark to sandmark where the number of 'valid' configurations for `n` queens on a chessboard of size `n` is calculated. 

We add both a single core and multicore version that uses tasks in a similar manner to how the Cilk nqueens benchmark.
