### PR TITLE
Cleanup our use of sudo for chrt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,8 @@ ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json
 	opam exec --switch $* -- rungen _build/$*_1 $(RUN_CONFIG_JSON) > runs_dune.inc;
 	opam exec --switch $* -- dune build --profile=release --workspace=ocaml-versions/.workspace.$* @$(BUILD_BENCH_TARGET);
 	@{ if [ "$(BUILD_ONLY)" -eq 0 ]; then												\
-		IS_PARALLEL=`grep -c chrt $(RUN_CONFIG_JSON)`; 										\
-		if [ "$$IS_PARALLEL" -gt 0 ]; then											\
-		  $(PRE_BENCH_EXEC) sudo -s OPAMROOT="${OPAMROOT}" OPAMROOTISOK="true" BUILD_BENCH_TARGET="${BUILD_BENCH_TARGET}" 	\
-	            RUN_BENCH_TARGET="${RUN_BENCH_TARGET}" RUN_CONFIG_JSON="${RUN_CONFIG_JSON}" opam exec --switch $* -- 		\
-		    dune build -j 1 --profile=release --workspace=ocaml-versions/.workspace.$* @$(RUN_BENCH_TARGET); ex=$$?; 		\
-		else															\
-		  $(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release 						\
-		    --workspace=ocaml-versions/.workspace.$* @$(RUN_BENCH_TARGET); ex=$$?;						\
-		fi;															\
+		$(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release 						\
+		  --workspace=ocaml-versions/.workspace.$* @$(RUN_BENCH_TARGET); ex=$$?;						\
 		for f in `find _build/$*_* -name '*.bench'`; do 									\
 		   d=`basename $$f | cut -d '.' -f 1,2`; 										\
 		   mkdir -p _results/$*/$$d/ ; cp $$f _results/$*/$$d/; 								\

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,13 @@ ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json
 	opam exec --switch $* -- rungen _build/$*_1 $(RUN_CONFIG_JSON) > runs_dune.inc;
 	opam exec --switch $* -- dune build --profile=release --workspace=ocaml-versions/.workspace.$* @$(BUILD_BENCH_TARGET);
 	@{ if [ "$(BUILD_ONLY)" -eq 0 ]; then												\
+     	echo "Executing benchmarks with:"; \
+     	echo "  RUN_CONFIG_JSON=${RUN_CONFIG_JSON}"; \
+     	echo "  RUN_BENCH_TARGET=${RUN_BENCH_TARGET}  (WRAPPER=${WRAPPER})"; \
+     	echo "  PRE_BENCH_EXEC=${PRE_BENCH_EXEC}"; \
 		$(PRE_BENCH_EXEC) opam exec --switch $* -- dune build -j 1 --profile=release 						\
 		  --workspace=ocaml-versions/.workspace.$* @$(RUN_BENCH_TARGET); ex=$$?;						\
-		for f in `find _build/$*_* -name '*.bench'`; do 									\
+		for f in `find _build/$*_* -name '*.$(WRAPPER).bench'`; do 									\
 		   d=`basename $$f | cut -d '.' -f 1,2`; 										\
 		   mkdir -p _results/$*/$$d/ ; cp $$f _results/$*/$$d/; 								\
 		done;															\

--- a/README.md
+++ b/README.md
@@ -120,15 +120,11 @@ You can execute both serial and parallel benchmarks using the
 Ensure that the respective .json configuration files have the
 appropriate settings.
 
-The run_all_parallel.sh script uses chrt and the user executing the
-script requires sudo with nopasswd permission, which is quite useful
-with periodic nightly builds. Using the `sudo visudo` command on
-Ubuntu, for example, you can add the following entry to the
-`/etc/sudoers` file to allow a user running the script to execute any
-command:
-
+If using `RUN_BENCH_TARGET=run_orunchrt` then the benchmarks will
+run using `chrt -r 1`. You may need to give the user permissions
+to execute `chrt`, one way to do this can be:
 ```
-username   ALL=(ALL:ALL) NOPASSWD: ALL
+sudo setcap cap_sys_nice=ep /usr/bin/chrt
 ```
 
 ### Running benchmarks
@@ -178,7 +174,7 @@ You can add new benchmarks as follows:
     already included in Sandmark, add its opam file to
     `dependencies/packages/<package-name>/<package-version>/opam`. If the
     package depends on other packages, repeat this step for all of those
-    packages. Add the package to `PACKAGES` variable in the Makefile.  
+    packages. Add the package to `PACKAGES` variable in the Makefile.
 
  - **Add benchmark files:**
     Find a relevant folder in `benchmarks/` and add your code to it. Feel free

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -5,6 +5,10 @@
       "command": "orun -o %{output} -- %{paramwrapper} %{command}"
     },
     {
+      "name": "orunchrt",
+      "command": "orun -o %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+    },
+    {
       "name": "perfstat",
       "command": "perf stat -o %{output} -- %{paramwrapper} %{command}"
     },
@@ -24,7 +28,7 @@
         {
           "params": "roomfront.ml.txt",
           "short_name": "roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         }
       ]
     },
@@ -36,42 +40,42 @@
         {
           "params": "1 roomfront.ml.txt",
           "short_name": "1_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
           "params": "2 roomfront.ml.txt",
           "short_name": "2_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
           "params": "4 roomfront.ml.txt",
           "short_name": "4_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
           "params": "8 roomfront.ml.txt",
           "short_name": "8_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
           "params": "12 roomfront.ml.txt",
           "short_name": "12_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
           "params": "16 roomfront.ml.txt",
           "short_name": "16_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
           "params": "20 roomfront.ml.txt",
           "short_name": "20_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
           "params": "24 roomfront.ml.txt",
           "short_name": "24_roomfront",
-          "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1"
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }
       ]
     },
@@ -81,7 +85,7 @@
       "name": "spectralnorm2",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "5_500" , "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"}
+        { "params": "5_500" , "paramwrapper": "taskset --cpu-list 2-13"}
       ]
     },
     {
@@ -89,14 +93,14 @@
       "name": "spectralnorm2_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 5_500", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 5_500", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 5_500", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 5_500", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 5_500", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 5_500", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 5_500", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 5_500", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 5_500", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 5_500", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 5_500", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -105,7 +109,7 @@
       "name": "mandelbrot6",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "16_000", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -113,14 +117,14 @@
       "name": "mandelbrot6_multicore",
       "tags": ["macro_bench", "run_in_ci"],
       "runs": [
-        { "params": "1 16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 16_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 16_000", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 16_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 16_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 16_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 16_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 16_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -129,7 +133,7 @@
       "name": "matrix_multiplication",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "1024", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -137,14 +141,14 @@
       "name": "matrix_multiplication_multicore",
       "tags": ["macro_bench", "run_in_ci"],
       "runs": [
-        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -152,11 +156,11 @@
       "name": "matrix_multiplication_tiling_multicore",
       "tags": [],
       "runs": [
-        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -165,7 +169,7 @@
       "name": "quicksort",
       "tags": [],
       "runs": [
-        { "params": "40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "40_000_000", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -173,14 +177,14 @@
       "name": "quicksort_multicore",
       "tags": [],
       "runs": [
-        { "params": "1 40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 40_000_000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 40_000_000", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 40_000_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 40_000_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 40_000_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 40_000_000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 40_000_000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -189,7 +193,7 @@
       "name": "binarytrees5",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "23", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -197,14 +201,14 @@
       "name": "binarytrees5_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 23", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 23", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 23", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 23", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 23", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 23", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 23", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 23", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 23", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 23", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 23", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 23", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -213,7 +217,7 @@
       "name": "game_of_life",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "256", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -221,14 +225,14 @@
       "name": "game_of_life_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 256", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 256", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 256", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 256", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 256", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 256", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 256", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 256", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 256", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 256", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 256", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 256", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -236,7 +240,7 @@
       "name": "LU_decomposition",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "2048", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -244,14 +248,14 @@
       "name": "LU_decomposition_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 2048", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -259,7 +263,7 @@
       "name": "floyd_warshall",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "1024", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -267,14 +271,14 @@
       "name": "floyd_warshall_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 1024", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 1024", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 1024", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 1024", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -282,7 +286,7 @@
       "name": "nbody",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "512 2048", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -290,14 +294,14 @@
       "name": "nbody_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 512 2048", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 512 2048", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 512 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 512 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 512 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 512 2048", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 512 2048", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -305,7 +309,7 @@
       "name": "evolutionary_algorithm",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "10000 10000", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -313,14 +317,14 @@
       "name": "evolutionary_algorithm_multicore",
       "tags": ["macro_bench", "run_in_ci"],
       "runs": [
-        { "params": "1 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 10000 10000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 10000 10000", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 10000 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 10000 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 10000 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 10000 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 10000 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
 
@@ -329,7 +333,7 @@
       "name": "test_decompress",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -337,14 +341,14 @@
       "name": "test_decompress_multicore",
       "tags": ["macro_bench", "run_in_ci"],
       "runs": [
-        { "params": "1 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 64 1_048_576", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -352,7 +356,7 @@
       "name": "grammatrix",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" }
+        { "params": "16", "paramwrapper": "taskset --cpu-list 2-13" }
       ]
     },
     {
@@ -360,14 +364,14 @@
       "name": "grammatrix_multicore",
       "tags": ["macro_bench"],
       "runs": [
-        { "params": "1 16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "2 16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 16", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 16", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 16", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 16", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "1 16", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "2 16", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 16", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 16", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 16", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 16", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 16", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 16", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {
@@ -375,14 +379,14 @@
       "name": "pingpong_multicore",
       "tags": [],
       "runs": [
-        { "params": "2 256 1000000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1"},
-        { "params": "4 256 1000000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "4 256 1000000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "8 256 1000000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "12 256 1000000", "paramwrapper": "taskset --cpu-list 2-13 chrt -r 1" },
-        { "params": "16 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "20 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" },
-        { "params": "24 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27 chrt -r 1" }
+        { "params": "2 256 1000000", "paramwrapper": "taskset --cpu-list 2-13"},
+        { "params": "4 256 1000000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "4 256 1000000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "8 256 1000000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "12 256 1000000", "paramwrapper": "taskset --cpu-list 2-13" },
+        { "params": "16 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "20 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+        { "params": "24 256 1000000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {

--- a/run_all_parallel.sh
+++ b/run_all_parallel.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-# Since the parallel benchmarks use `chrt -r 1` you will need to run this script
-# twice. First run without sudo which will build the compiler and the benchmarks,
-# and will fail running the benchmarks. Then run the script with sudo which will
-# run the benchmarks and produce the results.
+# If using RUN_BENCH_TARGET=run_orunchrt the parallel benchmarks
+# use `chrt -r 1`. You may need to setup permissions to allow the
+# user to execute `chrt`. For example, this could be done with:
+#   sudo setcap cap_sys_nice=ep /usr/bin/chrt
 #
-# $ bash run_all_parallel.sh; sudo bash run_all_parallel.sh
 
 make multicore_parallel_run_config_macro.json
 


### PR DESCRIPTION
This PR does a cleanup of using sudo with parallel tests. This caused me some pain recently when running big test instances (which take a long time O(hrs) to run) that failed because files were turning up with root permissions in strange places. 

The changes are:
 - remove sudo from the makefile; people should use the capability (or any other alternative) to allow them to run chrt
 - make using chrt an explicit wrapper target for `RUN_BENCH_TARGET`. We wanted to be able to benchmark with and without the chrt command.
 - be a bit more upfront in the console when the benchmarks run and the parameters being used (this is helpful for things that run for a long time, just in case the user has made a mistake)
 - document a method to set permissions for chrt on Linux and other changes to be in line with the above

Hopefully this will save others time in the future, although I'd be interested if there is a use case that people use which I've unexpectedly broken.