### PR TITLE
Clean up existing effect benchmarks

### DIFF
--- a/benchmarks/multicore-effects/algorithmic_differentiation.ml
+++ b/benchmarks/multicore-effects/algorithmic_differentiation.ml
@@ -48,7 +48,7 @@ end = struct
 end;;
 
 let iterations = int_of_string Sys.argv.(1) in
-  for iteration = 0 to iterations do
+  for _iteration = 1 to iterations do
     (* f = x + x^3 =>
       df/dx = 1 + 3 * x^2 *)
     for x = 0 to 10 do

--- a/benchmarks/multicore-effects/dune
+++ b/benchmarks/multicore-effects/dune
@@ -17,5 +17,5 @@
     (libraries lockfree))
 
 (alias
-		(name multibench_serial)
+		(name multibench_effects)
 		(deps algorithmic_differentiation.exe queens.exe eratosthenes.exe test_sched.exe))

--- a/benchmarks/multicore-effects/eratosthenes.ml
+++ b/benchmarks/multicore-effects/eratosthenes.ml
@@ -2,17 +2,17 @@
 
 (* A message is either a [Stop] signal or a [Candidate] prime number *)
 type message = Stop | Candidate of int
-    
+
 (** Process primitives **)
 type pid = int
-  
+
 effect Spawn : (pid -> unit) -> pid
 let spawn p = perform (Spawn p)
-  
-effect Yield : unit
-let yield () = perform Yield  
 
-(** Communication primitives **)
+effect Yield : unit
+let yield () = perform Yield
+
+(* Communication primitives *)
 effect Send : pid * message -> unit
 let send pid data =
   perform (Send (pid, data));
@@ -31,9 +31,9 @@ struct
   module Make (Ord : Map.OrderedType) =
   struct
     include Map.Make(Ord)
-      
+
     let empty = empty
-      
+
     let lookup key mb =
       try
         Some (find key mb)
@@ -56,10 +56,10 @@ struct
       | None ->
          let msg_q = Queue.create () in
          Queue.push msg msg_q;
-         add key msg_q mb    
-  end    
+         add key msg_q mb
+  end
 end
-    
+
 (** Communication handler **)
 let mailbox f =
   let module Mailbox = Mailbox.Make(struct type t = pid let compare = compare end) in
@@ -77,7 +77,7 @@ let mailbox f =
      let msg = lookup who in
      continue k msg
 
-(** Process handler 
+(** Process handler
     Slightly modified version of sched.ml **)
 let run main () =
   let run_q = Queue.create () in
@@ -97,12 +97,12 @@ let run main () =
        enqueue (fun () -> continue k !pid); spawn p
   in
   spawn main
-  
+
 let fromSome = function
   | Some x -> x
   | _ -> failwith "Attempt to unwrap None"
 
-(** The prime number generator **)     
+(** The prime number generator **)
 let rec generator : pid -> unit =
   fun _ ->
     let n =

--- a/benchmarks/multicore-effects/ms_sched.ml
+++ b/benchmarks/multicore-effects/ms_sched.ml
@@ -16,7 +16,7 @@ let run main =
   let enqueue k = MSQueue.push run_q k in
   let rec dequeue () =
     match MSQueue.pop run_q with
-    | None -> 
+    | None ->
         if Atomic.get exiting_flag then () else (Domain.Sync.cpu_relax(); dequeue ())
     | Some(y) -> (continue y ())
   in
@@ -30,7 +30,7 @@ let run main =
         ( enqueue k; dequeue () )
     | effect (Fork f) k ->
         ( enqueue k; spawn f )
-    | effect Exit k ->
+    | effect Exit _ ->
       ( Atomic.set exiting_flag true; dequeue () )
   in
   spawn main

--- a/benchmarks/multicore-effects/queens.ml
+++ b/benchmarks/multicore-effects/queens.ml
@@ -36,12 +36,11 @@ let find_solution n =
             | Some x -> Some x
       in loop lst
 
-let main () =
-  let n = 8 in
-    find_solution n
+let iterations = try int_of_string Sys.argv.(1) with _ -> 100
+let size = try int_of_string Sys.argv.(2) with _ -> 8
 
-let iterations = int_of_string Sys.argv.(1)
 
-let () = for iteration = 0 to iterations do
-    ignore(main ())
-done
+let () =
+  for _i = 1 to iterations do
+    ignore(find_solution size)
+  done

--- a/benchmarks/multicore-effects/test_sched.ml
+++ b/benchmarks/multicore-effects/test_sched.ml
@@ -1,4 +1,4 @@
-let num_domains = int_of_string Sys.argv.(1) 
+let num_domains = int_of_string Sys.argv.(1)
 
 let tasks_to_spawn = int_of_string Sys.argv.(2)
 
@@ -8,7 +8,7 @@ let rec create_list f n =
   match n with 0 -> [] | _ -> f n :: create_list f (n - 1)
 
 let start_task () =
-  for n = 0 to tasks_to_spawn do
+  for _n = 1 to tasks_to_spawn do
     Ms_sched.fork (fun _ ->
         ignore (Sys.opaque_identity create_list (fun n -> n + 1) list_length)
     )

--- a/multicore_effects_run_config.json
+++ b/multicore_effects_run_config.json
@@ -1,0 +1,46 @@
+{
+  "wrappers": [
+    {
+      "name": "orun",
+      "command": "orun -o %{output} -- %{command}"
+    },
+    {
+      "name": "perfstat",
+      "command": "perf stat -o %{output} -- %{command}"
+    }
+  ],
+  "benchmarks": [
+    {
+      "executable": "benchmarks/multicore-effects/algorithmic_differentiation.exe",
+      "name": "algorithmic_differentiation",
+      "tags": [],
+      "runs": [
+        { "params": "10_000" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/queens.exe",
+      "name": "queens",
+      "tags": [],
+      "runs": [
+        { "params": "1_000 12" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/test_sched.exe",
+      "name": "test_sched",
+      "tags": [],
+      "runs": [
+        { "params": "1 100_000 1_000" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/eratosthenes.exe",
+      "name": "eratosthenes",
+      "tags": [],
+      "runs": [
+        { "params": "5001" }
+      ]
+    }
+  ]
+}

--- a/run_all_effects.sh
+++ b/run_all_effects.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+BUILD_BENCH_TARGET=multibench_effects \
+	RUN_CONFIG_JSON=multicore_effects_run_config.json \
+	make ocaml-versions/4.10.0+multicore.bench


### PR DESCRIPTION
This PR cleans up the existing multicore effect benchmarks that we have in sandmark. 

It gets the existing code compiling cleanly (without warnings), adds a `multicore_effects_run_config.json` config for the existing effect benchmarks, adds a `run_all_effect.sh` script to run things.
