### PR TITLE
Very simple effect microbenchmarks to cover code paths

### DIFF
--- a/benchmarks/multicore-effects/dune
+++ b/benchmarks/multicore-effects/dune
@@ -1,3 +1,21 @@
+
+
+(executables
+    (names effect_throughput_clone)
+    (modules effect_throughput_clone))
+
+(executables
+    (names effect_throughput_perform)
+    (modules effect_throughput_perform))
+
+(executables
+    (names effect_throughput_perform_drop)
+    (modules effect_throughput_perform_drop))
+
+(executables
+    (names effect_throughput_val)
+    (modules effect_throughput_val))
+
 (executables
     (names algorithmic_differentiation)
     (modules algorithmic_differentiation))
@@ -18,4 +36,4 @@
 
 (alias
 		(name multibench_effects)
-		(deps algorithmic_differentiation.exe queens.exe eratosthenes.exe test_sched.exe))
+		(deps algorithmic_differentiation.exe queens.exe eratosthenes.exe test_sched.exe effect_throughput_clone.exe effect_throughput_perform.exe effect_throughput_perform_drop.exe effect_throughput_val.exe))

--- a/benchmarks/multicore-effects/effect_throughput_clone.ml
+++ b/benchmarks/multicore-effects/effect_throughput_clone.ml
@@ -1,0 +1,38 @@
+(*
+ *  This test intends to measure the throughput of continuation cloning.
+ *  It will include:
+ *    - cloning the continuation
+ *    - switching stack to the new stack
+ *    - returning from the new stack and freeing the stack
+ *)
+
+let n_iter = try int_of_string Sys.argv.(1) with _ -> 1_000_000
+
+let now = Sys.time
+
+effect E : int -> int
+
+let g () = perform (E 1)
+
+let h () =
+    let t0 = now () in
+
+    ignore (
+        match g () with
+        | effect (E x) k -> begin
+            for _ = 1 to n_iter do
+                ignore (Sys.opaque_identity(
+                    continue (Obj.clone_continuation k) x
+                ))
+            done;
+            continue k x
+        end
+        | x -> x
+        );
+
+    let t = (now ()) -. t0 in
+    Printf.printf "%i iterations took %f\n%!" n_iter t;
+    Printf.printf "%.1fns per iteration\n%!" ((t*.1e9)/. (float_of_int n_iter))
+
+let _ = h ()
+

--- a/benchmarks/multicore-effects/effect_throughput_perform.ml
+++ b/benchmarks/multicore-effects/effect_throughput_perform.ml
@@ -1,0 +1,38 @@
+(*
+ *  This test intends to measure the throughput of an effect handler
+ *  block where perform is called, then the continuation resumed
+ *  and a value is returned.
+ *  It will include:
+ *    - new stack creation for the function to be executed
+ *    - switching stack to the new stack
+ *    - doing the perform and switching stacks back to the old stack
+ *    - resuming the continuation
+ *    - switching stacks back to the old stack with a value return
+ *    - freeing the stack created to evaluate the function
+ *)
+
+let n_iter = try int_of_string Sys.argv.(1) with _ -> 1_000_000
+
+let now = Sys.time
+
+effect E : int -> int
+
+let g () = perform (E 1)
+
+let h () =
+    let t0 = now () in
+
+    for _ = 1 to n_iter do
+        ignore (Sys.opaque_identity(
+            match g () with
+            | effect (E x) k -> continue k x
+            | x -> x
+        ))
+    done;
+
+    let t = (now ()) -. t0 in
+    Printf.printf "%i iterations took %f\n%!" n_iter t;
+    Printf.printf "%.1fns per iteration\n%!" ((t*.1e9)/. (float_of_int n_iter))
+
+let _ = h ()
+

--- a/benchmarks/multicore-effects/effect_throughput_perform_drop.ml
+++ b/benchmarks/multicore-effects/effect_throughput_perform_drop.ml
@@ -1,0 +1,35 @@
+(*
+ *  This test intends to measure the throughput of an effect handler
+ *  block where perform is called but does not return to the continuation.
+ *  It will include:
+ *    - new stack creation for the function to be executed
+ *    - switching stack to the new stack
+ *    - doing the perform and switching stacks back to the old stack
+ *    - any garbage collection of the continuation that is ignored
+ *)
+
+let n_iter = try int_of_string Sys.argv.(1) with _ -> 1_000_000
+
+let now = Sys.time
+
+effect E : int -> int
+
+let g () = perform (E 1)
+
+let h () =
+    let t0 = now () in
+
+    for _ = 1 to n_iter do
+        ignore (Sys.opaque_identity(
+            match g () with
+            | effect (E x) _k -> x
+            | x -> x
+        ))
+    done;
+
+    let t = (now ()) -. t0 in
+    Printf.printf "%i iterations took %f\n%!" n_iter t;
+    Printf.printf "%.1fns per iteration\n%!" ((t*.1e9)/. (float_of_int n_iter))
+
+let _ = h ()
+

--- a/benchmarks/multicore-effects/effect_throughput_val.ml
+++ b/benchmarks/multicore-effects/effect_throughput_val.ml
@@ -1,0 +1,35 @@
+(*
+ *  This test intends to measure the throughput of an effect handler
+ *  block where perform is never called and a value is returned.
+ *  It will include:
+ *    - new stack creation for the function to be executed
+ *    - switching stack to the new stack
+ *    - switching stacks back to the old stack with a value return
+ *    - freeing the stack created to evaluate the function
+ *)
+
+let n_iter = try int_of_string Sys.argv.(1) with _ -> 1_000_000
+
+let now = Sys.time
+
+effect E : unit
+
+let g () = 1
+
+let h () =
+    let t0 = now () in
+
+    for _ = 1 to n_iter do
+        ignore (Sys.opaque_identity(
+            match g () with
+            | effect E _k -> assert false
+            | x -> x
+        ))
+    done;
+
+    let t = (now ()) -. t0 in
+    Printf.printf "%i iterations took %f\n%!" n_iter t;
+    Printf.printf "%.1fns per iteration\n%!" ((t*.1e9)/. (float_of_int n_iter))
+
+let _ = h ()
+

--- a/multicore_effects_run_config.json
+++ b/multicore_effects_run_config.json
@@ -41,6 +41,38 @@
       "runs": [
         { "params": "5001" }
       ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/effect_throughput_clone.exe",
+      "name": "throughput_clone",
+      "tags": [],
+      "runs": [
+        { "params": "2_000_000" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/effect_throughput_perform.exe",
+      "name": "throughput_perform",
+      "tags": [],
+      "runs": [
+        { "params": "2_000_000" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/effect_throughput_perform_drop.exe",
+      "name": "throughput_perform_drop",
+      "tags": [],
+      "runs": [
+        { "params": "2_000_000" }
+      ]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/effect_throughput_val.exe",
+      "name": "throughput_val",
+      "tags": [],
+      "runs": [
+        { "params": "2_000_000" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR introduces very simple micro benchmarks that are looking at the throughput of our effects system.

In particular it has 4 tests:
 - `effect_throughput_clone`: this captures a continuation and then does `continue (Obj.clone_continuation k) x` on it. 
 - `effect_throughput_val`: this executes a function inside an effect handler, but returns without performing an effect. 
 - `effect_throughput_perform`: this executes a function inside an effect handler, performs an effect, which resumes the continuation which exits with a value.
 - `effect_throughput_perform_drop`: this executes a function inside an effect handler, performs an effect, which drops the continuation and so the exit is from the effect handler itself.

These tests are not exhaustive, but are intended to give code coverage to flush out any gross inefficiencies and can be useful for CI/debugging purposes. 

I'm open to more or better versions of the above. 