### PR TITLE
Implementation of 'recursion' benchmarks for effects

### DIFF
--- a/benchmarks/multicore-effects/dune
+++ b/benchmarks/multicore-effects/dune
@@ -1,4 +1,63 @@
 
+(executable
+ (name rec_seq_ack)
+ (modules rec_seq_ack)
+)
+
+(executable
+ (name rec_eff_ack)
+ (modules rec_eff_ack)
+)
+
+(executable
+ (name rec_seq_evenodd)
+ (modules rec_seq_evenodd)
+)
+
+(executable
+ (name rec_eff_evenodd)
+ (modules rec_eff_evenodd)
+)
+
+(executable
+ (name rec_seq_fib)
+ (modules rec_seq_fib)
+)
+
+(executable
+ (name rec_eff_fib)
+ (modules rec_eff_fib)
+)
+
+(executable
+ (name rec_seq_motzkin)
+ (modules rec_seq_motzkin)
+)
+
+(executable
+ (name rec_eff_motzkin)
+ (modules rec_eff_motzkin)
+)
+
+(executable
+ (name rec_seq_tak)
+ (modules rec_seq_tak)
+)
+
+(executable
+ (name rec_eff_tak)
+ (modules rec_eff_tak)
+)
+
+(executable
+ (name rec_seq_sudan)
+ (modules rec_seq_sudan)
+)
+
+(executable
+ (name rec_eff_sudan)
+ (modules rec_eff_sudan)
+)
 
 (executables
     (names effect_throughput_clone)
@@ -36,4 +95,6 @@
 
 (alias
 		(name multibench_effects)
-		(deps algorithmic_differentiation.exe queens.exe eratosthenes.exe test_sched.exe effect_throughput_clone.exe effect_throughput_perform.exe effect_throughput_perform_drop.exe effect_throughput_val.exe))
+		(deps algorithmic_differentiation.exe queens.exe eratosthenes.exe test_sched.exe
+        effect_throughput_clone.exe effect_throughput_perform.exe effect_throughput_perform_drop.exe effect_throughput_val.exe
+        rec_seq_ack.exe rec_eff_ack.exe rec_seq_evenodd.exe rec_eff_evenodd.exe rec_seq_fib.exe rec_eff_fib.exe rec_seq_motzkin.exe rec_eff_motzkin.exe rec_seq_tak.exe rec_eff_tak.exe rec_seq_sudan.exe rec_eff_sudan.exe))

--- a/benchmarks/multicore-effects/rec_eff_ack.ml
+++ b/benchmarks/multicore-effects/rec_eff_ack.ml
@@ -1,0 +1,25 @@
+(* compute the Ackermann function
+ * (see Larcenry benchmarks http://www.larcenists.org/benchmarksAboutR6.html) *)
+
+(* the usage of a new continuation is limited to the nested call *)
+
+effect E : unit
+
+let rec ack m n =
+  if m = 0 then n + 1
+  else if n = 0 then ack (m-1) 1
+  else ack (m-1) (try ack m (n-1) with effect E _ -> assert false)
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 2 in
+  let m = try int_of_string Sys.argv.(2) with _ -> 3 in
+  let n = try int_of_string Sys.argv.(3) with _ -> 11 in
+  (* default output should be 16381 *)
+
+  run (fun () -> ack m n) iters

--- a/benchmarks/multicore-effects/rec_eff_evenodd.ml
+++ b/benchmarks/multicore-effects/rec_eff_evenodd.ml
@@ -1,0 +1,23 @@
+(* even-odd MLton benchmark adapted *)
+
+effect E : unit
+
+let rec even n =
+  if n = 0 then true
+  else try odd (n-1) with effect E _ -> assert false
+and odd n =
+  if n = 0 then false
+  else even (n-1)
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%B\n%!" x; x)
+  else repeat f ((f ()) || acc) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f false n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 2 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 500_000_000 in
+  (* expect result to be true for even numbers *)
+
+  run (fun () -> (even n) && (not (odd n))) iters

--- a/benchmarks/multicore-effects/rec_eff_fib.ml
+++ b/benchmarks/multicore-effects/rec_eff_fib.ml
@@ -1,0 +1,27 @@
+(* compute fib recursively
+ * with each recursion in its own fiber
+ *)
+
+effect E : unit
+
+let rec fib n =
+  match n with
+  | 0 -> 0
+  | 1 -> 1
+  | n -> begin
+        (try (fib (n-1)) with effect E _ -> (assert false))
+      + (try (fib (n-2)) with effect E _ -> (assert false))
+  end
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 4 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 40 in
+  (* default output should be 102334155 *)
+
+  run (fun () -> fib n) iters

--- a/benchmarks/multicore-effects/rec_eff_motzkin.ml
+++ b/benchmarks/multicore-effects/rec_eff_motzkin.ml
@@ -1,0 +1,39 @@
+(*
+   "the n'th Motzkin number is the number of different ways of drawing
+   non-intersecting chords between n points on a circle
+   (not necessarily touching every point by a chord)."
+    https://en.wikipedia.org/wiki/Motzkin_number
+    See here for input/outputs: https://oeis.org/A001006/list
+*)
+
+effect E : unit
+
+let rec sum f i stop acc =
+	if i > stop then acc
+  else sum f (i+1) stop (acc + (f i))
+
+let rec motz n =
+	if n <= 1 then 1
+	else begin
+		let limit = n - 2 in
+		let product i =
+        (try motz i with effect E _ -> assert false)
+      * (try motz (limit -i) with effect E _ -> assert false)
+    in
+		(try motz (n-1) with effect E _ -> assert false) +
+    (try sum product 0 limit 0 with effect E _ -> assert false)
+	end
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 4 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 21 in
+  (* default output should be 142547559 *)
+
+  run (fun () -> motz n) iters
+

--- a/benchmarks/multicore-effects/rec_eff_sudan.ml
+++ b/benchmarks/multicore-effects/rec_eff_sudan.ml
@@ -1,0 +1,30 @@
+(*
+   Sudan function, which is recursive but not primitive recursive:
+      https://en.wikipedia.org/wiki/Sudan_function
+*)
+
+effect E : unit
+
+let rec sudan n x y =
+  if n = 0 then x + y
+  else if y = 0 then x
+  else begin
+    let inner = try sudan n x (y-1) with effect E _ -> assert false in
+    sudan (n-1) inner (inner+y)
+  end
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 10_000_000 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 2 in
+  let x = try int_of_string Sys.argv.(3) with _ -> 2 in
+  let y = try int_of_string Sys.argv.(4) with _ -> 2 in
+  (* default output should be 15569256417 *)
+
+  run (fun () -> sudan n x y) iters
+

--- a/benchmarks/multicore-effects/rec_eff_tak.ml
+++ b/benchmarks/multicore-effects/rec_eff_tak.ml
@@ -1,0 +1,25 @@
+(* compute tak function *)
+
+effect E : unit
+
+let rec tak x y z =
+  if y < x then tak
+            (try tak (x-1) y z with effect E _ -> assert false)
+            (try tak (y-1) z x with effect E _ -> assert false)
+            (try tak (z-1) x y with effect E _ -> assert false)
+           else z
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 1 in
+  let x = try int_of_string Sys.argv.(2) with _ -> 40 in
+  let y = try int_of_string Sys.argv.(3) with _ -> 20 in
+  let z = try int_of_string Sys.argv.(4) with _ -> 11 in
+  (* default output should be 12 *)
+
+  run (fun () -> tak x y z) iters

--- a/benchmarks/multicore-effects/rec_seq_ack.ml
+++ b/benchmarks/multicore-effects/rec_seq_ack.ml
@@ -1,0 +1,22 @@
+(* compute the Ackermann function
+ * (see Larcenry benchmarks http://www.larcenists.org/benchmarksAboutR6.html) *)
+
+let rec ack m n =
+  if m = 0 then n + 1
+  else if n = 0 then ack (m-1) 1
+  else ack (m-1) (ack m (n-1))
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 2 in
+  let m = try int_of_string Sys.argv.(2) with _ -> 3 in
+  let n = try int_of_string Sys.argv.(3) with _ -> 11 in
+  (* default output should be 16381 *)
+
+  run (fun () -> ack m n) iters
+

--- a/benchmarks/multicore-effects/rec_seq_evenodd.ml
+++ b/benchmarks/multicore-effects/rec_seq_evenodd.ml
@@ -1,0 +1,21 @@
+(* even-odd MLton benchmark adapted *)
+
+let rec even n =
+  if n = 0 then true
+  else odd (n-1)
+and odd n =
+  if n = 0 then false
+  else even (n-1)
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%B\n%!" x; x)
+  else repeat f ((f ()) || acc) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f false n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 2 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 500_000_000 in
+  (* expect result to be true for even numbers *)
+
+  run (fun () -> (even n) && (not (odd n))) iters

--- a/benchmarks/multicore-effects/rec_seq_fib.ml
+++ b/benchmarks/multicore-effects/rec_seq_fib.ml
@@ -1,0 +1,20 @@
+(* compute fib recursively *)
+
+let rec fib n =
+  match n with
+  | 0 -> 0
+  | 1 -> 1
+  | n -> (fib (n-1) + fib (n-2))
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 4 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 40 in
+  (* default output should be 102334155 *)
+
+  run (fun () -> fib n) iters

--- a/benchmarks/multicore-effects/rec_seq_motzkin.ml
+++ b/benchmarks/multicore-effects/rec_seq_motzkin.ml
@@ -1,0 +1,33 @@
+(*
+   "the n'th Motzkin number is the number of different ways of drawing
+   non-intersecting chords between n points on a circle
+   (not necessarily touching every point by a chord)."
+    https://en.wikipedia.org/wiki/Motzkin_number
+    See here for input/outputs: https://oeis.org/A001006/list
+*)
+
+let rec sum f i stop acc =
+	if i > stop then acc
+  else sum f (i+1) stop (acc + (f i))
+
+let rec motz n =
+	if n <= 1 then 1
+	else begin
+		let limit = n - 2 in
+		let product i = (motz i) * (motz (limit -i)) in
+		motz (n-1) + (sum product 0 limit 0)
+	end
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 4 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 21 in
+  (* default output should be 142547559 *)
+
+  run (fun () -> motz n) iters
+

--- a/benchmarks/multicore-effects/rec_seq_sudan.ml
+++ b/benchmarks/multicore-effects/rec_seq_sudan.ml
@@ -1,0 +1,27 @@
+(*
+   Sudan function, which is recursive but not primitive recursive:
+      https://en.wikipedia.org/wiki/Sudan_function
+*)
+
+let rec sudan n x y =
+  if n = 0 then x + y
+  else if y = 0 then x
+  else begin
+  	let inner = sudan n x (y-1) in
+  	sudan (n-1) inner (inner+y)
+  end
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 10_000_000 in
+  let n = try int_of_string Sys.argv.(2) with _ -> 2 in
+  let x = try int_of_string Sys.argv.(3) with _ -> 2 in
+  let y = try int_of_string Sys.argv.(4) with _ -> 2 in
+  (* default output should be 15569256417 *)
+
+  run (fun () -> sudan n x y) iters

--- a/benchmarks/multicore-effects/rec_seq_tak.ml
+++ b/benchmarks/multicore-effects/rec_seq_tak.ml
@@ -1,0 +1,20 @@
+(* compute tak function *)
+
+let rec tak x y z =
+  if y < x then tak (tak (x-1) y z) (tak (y-1) z x) (tak (z-1) x y)
+           else z
+
+let rec repeat f acc n =
+  if n = 1 then let x = f () in (Printf.printf "%d\n%!" x; x)
+  else repeat f (acc + (f ())) (n-1)
+
+let run f n = ignore (Sys.opaque_identity (repeat f 0 n))
+
+let _ =
+  let iters = try int_of_string Sys.argv.(1) with _ -> 1 in
+  let x = try int_of_string Sys.argv.(2) with _ -> 40 in
+  let y = try int_of_string Sys.argv.(3) with _ -> 20 in
+  let z = try int_of_string Sys.argv.(4) with _ -> 11 in
+  (* default output should be 12 *)
+
+  run (fun () -> tak x y z) iters

--- a/multicore_effects_run_config.json
+++ b/multicore_effects_run_config.json
@@ -45,34 +45,98 @@
     {
       "executable": "benchmarks/multicore-effects/effect_throughput_clone.exe",
       "name": "throughput_clone",
-      "tags": [],
-      "runs": [
-        { "params": "2_000_000" }
-      ]
+      "tags": ["throughput"],
+      "runs": [{ "params": "2_000_000" }]
     },
     {
       "executable": "benchmarks/multicore-effects/effect_throughput_perform.exe",
       "name": "throughput_perform",
-      "tags": [],
-      "runs": [
-        { "params": "2_000_000" }
-      ]
+      "tags": ["throughput"],
+      "runs": [{ "params": "2_000_000" }]
     },
     {
       "executable": "benchmarks/multicore-effects/effect_throughput_perform_drop.exe",
       "name": "throughput_perform_drop",
-      "tags": [],
-      "runs": [
-        { "params": "2_000_000" }
-      ]
+      "tags": ["throughput"],
+      "runs": [{ "params": "2_000_000" }]
     },
     {
       "executable": "benchmarks/multicore-effects/effect_throughput_val.exe",
       "name": "throughput_val",
-      "tags": [],
-      "runs": [
-        { "params": "2_000_000" }
-      ]
+      "tags": ["throughput"],
+      "runs": [{ "params": "2_000_000" }]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_ack.exe",
+      "name": "rec_seq_ack",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 3 11"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_ack.exe",
+      "name": "rec_eff_ack",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 3 11"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_evenodd.exe",
+      "name": "rec_seq_evenodd",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 500_000_000"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_evenodd.exe",
+      "name": "rec_eff_evenodd",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 500_000_000"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_fib.exe",
+      "name": "rec_seq_fib",
+      "tags": ["recursive"],
+      "runs": [ {"params": "4 40"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_fib.exe",
+      "name": "rec_eff_fib",
+      "tags": ["recursive"],
+      "runs": [ {"params": "4 40"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_motzkin.exe",
+      "name": "rec_seq_motzkin",
+      "tags": ["recursive"],
+      "runs": [ {"params": "4 21"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_motzkin.exe",
+      "name": "rec_eff_motzkin",
+      "tags": ["recursive"],
+      "runs": [ {"params": "4 21"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_tak.exe",
+      "name": "rec_seq_tak",
+      "tags": ["recursive"],
+      "runs": [ {"params": "1 40 20 11"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_tak.exe",
+      "name": "rec_eff_tak",
+      "tags": ["recursive"],
+      "runs": [ {"params": "1 40 20 11"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_seq_sudan.exe",
+      "name": "rec_seq_sudan",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 2 2"}]
+    },
+    {
+      "executable": "benchmarks/multicore-effects/rec_eff_sudan.exe",
+      "name": "rec_eff_sudan",
+      "tags": ["recursive"],
+      "runs": [ {"params": "2 2 2"}]
     }
   ]
 }


### PR DESCRIPTION
This PR implements a collection of 'recursion' benchmarks for looking at the overheads of effects and inspired by the Manticore benchmarks:
 https://github.com/ManticoreProject/benchmark/

The aim it to display the overhead of using effects to spawn stacks for recursive functions over a standard recursive function. It also provides more benchmarks for tuning our effects performance in multicore. 

I had to make some (possibly arbitrary) naming choices:
 - I have added all these to `benchmarks/multicore-effects` to keep the code in one place at the cost of things starting to get crowded
 - I have tagged these as `recursive` in the run_config json file so there is a tag people can use to filter
 - I used the convention `rec_{seq,eff}_{benchmark}.ml` to name these `rec` for `recursive` and `{seq,eff}` for `{sequential,effect}`.

If people have strong views on a better naming, but there is an overhead to keeping all the bits of dune, filenames and json in sync. 

(Right now, there is a known issue with effects segfaulting on oddeven: ocaml-multicore/ocaml-multicore#421, but I don't believe that should hold up the code here)