### PR TITLE
Add environment support for wrapper in JSON configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json setup_sys_dune
 	  >> dependencies/packages/ocaml-base-compiler/ocaml-base-compiler.$*/opam
 	$(eval OCAML_CONFIG_OPTION = $(shell jq -r '.configure // empty' ocaml-versions/$*.json))
 	$(eval OCAML_RUN_PARAM     = $(shell jq -r '.runparams // empty' ocaml-versions/$*.json))
-	$(eval ENVIRONMENT = $(shell jq -r '.wrappers[] | select(.name=="$(WRAPPER)") | .environment // empty' "$(RUN_CONFIG_JSON)" ))
 	opam update
 	OCAMLRUNPARAM="$(OCAML_RUN_PARAM)" OCAMLCONFIGOPTION="$(OCAML_CONFIG_OPTION)" opam switch create --keep-build-dir --yes $* ocaml-base-compiler.$*
 	opam pin add -n --yes --switch $* orun orun/
@@ -108,6 +107,7 @@ blah:
 	@echo ${PACKAGES}
 
 ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json _opam/% .FORCE
+	$(eval ENVIRONMENT = $(shell jq -r '.wrappers[] | select(.name=="$(WRAPPER)") | .environment // empty' "$(RUN_CONFIG_JSON)" ))
 	@opam update
 	opam install --switch=$* --keep-build-dir --yes rungen orun
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)


### PR DESCRIPTION
The following PR implements `Option A` as mentioned in https://github.com/ocaml-bench/sandmark/issues/184. An (optional) `environment` parameter can specified for a wrapper entry in `run_config*.json` as shown below:
```
    {
      "name": "orun_2M",
      "environment": "OCAMLRUNPARAM='s=2M'",
      "command": "orun -o %{output} -- taskset --cpu-list 5 %{command}"
    },

```
* You can simply add multiple `variable=values` entries to the `environment` parameter value, and it will be passed during run-time execution.
* The `subst` in the Makefile to extract the wrapper name has been replaced by `patsubst` to allow bench target names with underscore like `run_orun_2M`.

You can run the above using:
```
$ RUN_BENCH_TARGET=run_orun_2M make ocaml-versions/4.10.0+multicore.bench
```