### PR TITLE
Filter benchmarks based on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,8 +17,8 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - make run_config_ci.json
-  - RUN_CONFIG_JSON=run_config_ci.json make ocaml-versions/4.10.0+stock.bench
+  - TAG='"run_in_ci"' make run_config_filtered.json
+  - RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+stock.bench
 
 ---
 kind: pipeline
@@ -40,8 +40,8 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - make run_config_ci.json
-  - RUN_CONFIG_JSON=run_config_ci.json make ocaml-versions/4.10.0+multicore.bench
+  - TAG='"run_in_ci"' make run_config_filtered.json
+  - RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+stock.bench
 
 ---
 kind: pipeline
@@ -63,5 +63,7 @@ steps:
   - opam install dune.2.6.0
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
-  - make multicore_parallel_run_config_macro_2domains_ci.json
-  - BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_macro_2domains_ci.json make ocaml-versions/4.10.0+multicore.bench
+  - TAG='"run_in_ci"' make multicore_parallel_run_config_filtered.json
+  - TAG='"macro_bench"' make multicore_parallel_run_config_filtered_filtered.json
+  - make multicore_parallel_run_config_filtered_filtered_2domains.json
+  - BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.10.0+multicore.bench

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ _results
 runs_dune.inc
 *~
 *.swp
-*_macro.json
-*_parallel.json
+*_filtered.json
 .ipynb_checkpoints

--- a/Makefile
+++ b/Makefile
@@ -171,11 +171,8 @@ bash:
 	bash
 	@echo "[opam subshell completed]"
 
-%_macro.json: %.json
-	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index("macro_bench") != null)]}' < $< > $@
+%_filtered.json: %.json
+	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index($(TAG)) != null)]}' < $< > $@
 
-%_macro_2domains.json: %_macro.json
-	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index("macro_bench") != null)]} | {wrappers : .wrappers, benchmarks : [.benchmarks | .[] | select(.tags | index("macro_bench") != null) | {executable : .executable, name: .name, tags: .tags, runs : [.runs | .[] as $$item | if ($$item | .params | split(" ") | .[0] ) == "2" then $$item | .paramwrapper |= "" else empty end ] } ]}' < $< > $@
-
-%_ci.json: %.json
-	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index("run_in_ci") != null)]}' < $< > $@
+%_2domains.json: %.json
+	jq '{wrappers : .wrappers, benchmarks : [.benchmarks | .[] | {executable : .executable, name: .name, tags: .tags, runs : [.runs | .[] as $$item | if ($$item | .params | split(" ") | .[0] ) == "2" then $$item | .paramwrapper |= "" else empty end ] } ] }' < $< > $@

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ clean:
 	rm -rf _build
 	rm -rf _opam
 	rm -rf _results
-	rm -rf *_macro*.json *ci.json
+	rm -rf *filtered.json
 	rm -rf *~
 
 list:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ and the default value is `run_config.json`. This file lists the executable to
 run and the wrapper which will be used to collect data (e.g. orun or perf). You
 can edit this file to change benchmark parameters or wrappers.
 
+The benchmarks also have associated tags which classify the benchmarks. The
+current tags are:
+
+* `macro_bench` - A macro benchmark.
+* `run_in_ci` - This benchmark is run in the CI.
+* `lt_1s` - running time is less than 1s on the `turing` machine.
+* `1s_10s` - running time is between 1s and 10s on the `turning` machine.
+* `10s_100s` - running time is between 10s and 100s on the `turing` machine.
+* `gt_100s` - running time is greater than 100s on the `turing` machine.
+
+The benchmarking machine `turing` is an Intel Xeon Gold 5120 CPU with 64GB of
+RAM housed at IITM.
+
+The `run_config.json` file may be filtered based on the tag. For example,
+
+```bash
+$ TAG='"macro_bench"' make run_config_filtered.json
+```
+
+filters the `run_config.json` file to only contain the benchmarks tagged as
+`macro_bench`.
+
 The build bench target determines the type of benchmark being built. It can be
 specified with the environment variable `BUILD_BENCH_TARGET`, and the default
 value is `buildbench` which runs the serial benchmarks. For executing the

--- a/run_all_parallel.sh
+++ b/run_all_parallel.sh
@@ -6,24 +6,24 @@
 #   sudo setcap cap_sys_nice=ep /usr/bin/chrt
 #
 
-make multicore_parallel_run_config_macro.json
+TAG='"macro_bench"' make multicore_parallel_run_config_filtered.json
 
 RUN_BENCH_TARGET=run_pausetimes_multicore BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.06.1+multicore+pausetimes+parallel.bench
 RUN_BENCH_TARGET=run_pausetimes_multicore BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.06.1+multicore+stw+pausetimes+parallel.bench
 RUN_BENCH_TARGET=run_pausetimes_multicore BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.10.0+multicore+pausetimes+parallel.bench
 
 BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.06.1+multicore+parallel.bench
 BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.06.1+multicore+stw+parallel.bench
 BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_macro.json \
+	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
 	make ocaml-versions/4.10.0+multicore+parallel.bench

--- a/run_all_serial.sh
+++ b/run_all_serial.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-make run_config_macro.json
+TAG='"macro_bench"' make run_config_filtered.json
 
-RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+multicore.bench
-RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+multicore+pausetimes.bench
+RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+multicore.bench
+RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+multicore+pausetimes.bench
 
-RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+multicore+stw.bench
-RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+multicore+stw+pausetimes.bench
+RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+multicore+stw.bench
+RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+multicore+stw+pausetimes.bench
 
-RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+stock.bench
-RUN_BENCH_TARGET=run_pausetimes_trunk RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.06.1+stock+instrumented.bench
+RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+stock.bench
+RUN_BENCH_TARGET=run_pausetimes_trunk RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.06.1+stock+instrumented.bench
 
-RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.10.0+multicore.bench
-RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.10.0+multicore+pausetimes.bench
+RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+multicore.bench
+RUN_BENCH_TARGET=run_pausetimes_multicore RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+multicore+pausetimes.bench
 
-RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.10.0+stock.bench
-RUN_BENCH_TARGET=run_pausetimes_trunk RUN_CONFIG_JSON=run_config_macro.json make ocaml-versions/4.10.0+stock+instrumented.bench
+RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+stock.bench
+RUN_BENCH_TARGET=run_pausetimes_trunk RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+stock+instrumented.bench

--- a/run_config.json
+++ b/run_config.json
@@ -483,7 +483,7 @@
     {
       "executable": "frama-c",
       "name": "frama-c",
-      "tags": [ 
+      "tags": [
         "macro_bench"
       ],
       "runs": [
@@ -741,7 +741,7 @@
         }
     ]
   },
-  
+
   {
       "executable": "benchmarks/simple-tests/stress.exe",
       "name": "stress",
@@ -1274,7 +1274,7 @@
       "name": "str_bench",
       "tags": ["1s_10s"],
       "runs": [
-       
+
         {
           "params": "str_search_forward 5000000"
         },


### PR DESCRIPTION
Remove the custom targets `_macro.json` and `_ci.json` and replace that with a generic solution. See #195. 