### PR TITLE
global roots microbenchmark

### DIFF
--- a/benchmarks/multicore-gcroots/dune
+++ b/benchmarks/multicore-gcroots/dune
@@ -1,0 +1,19 @@
+(executable
+ (name globroots_seq)
+ (modules globroots_seq)
+ (libraries globroots))
+
+(executable
+ (name globroots_sp)
+ (modules globroots_sp)
+ (libraries domainslib globroots))
+
+(executable
+ (name globroots_mp)
+ (modules globroots_mp)
+ (libraries globroots))
+
+(alias (name buildbench) (deps globroots_seq.exe))
+
+(alias (name multibench_parallel)
+  (deps globroots_seq.exe globroots_sp.exe globroots_mp.exe))

--- a/benchmarks/multicore-gcroots/dune
+++ b/benchmarks/multicore-gcroots/dune
@@ -13,7 +13,5 @@
  (modules globroots_mp)
  (libraries globroots))
 
-(alias (name buildbench) (deps globroots_seq.exe))
-
 (alias (name multibench_parallel)
   (deps globroots_seq.exe globroots_sp.exe globroots_mp.exe))

--- a/benchmarks/multicore-gcroots/globroots/dune
+++ b/benchmarks/multicore-gcroots/globroots/dune
@@ -1,0 +1,3 @@
+(library
+ (name globroots)
+ (foreign_stubs (language c) (names globrootsprim)))

--- a/benchmarks/multicore-gcroots/globroots/globroots.ml
+++ b/benchmarks/multicore-gcroots/globroots/globroots.ml
@@ -1,0 +1,73 @@
+module type GLOBREF = sig
+  type t
+  val register: string -> t
+  val get: t -> string
+  val set: t -> string -> unit
+  val remove: t -> unit
+end
+
+module Classic : GLOBREF = struct
+  type t
+  external register: string -> t = "gb_classic_register"
+  external get: t -> string = "gb_get"
+  external set: t -> string -> unit = "gb_classic_set"
+  external remove: t -> unit = "gb_classic_remove"
+end
+
+module Generational : GLOBREF = struct
+  type t
+  external register: string -> t = "gb_generational_register"
+  external get: t -> string = "gb_get"
+  external set: t -> string -> unit = "gb_generational_set"
+  external remove: t -> unit = "gb_generational_remove"
+end
+
+module Test(G: GLOBREF) = struct
+
+  let size = 1024
+
+  let vals = Array.init size Int.to_string
+
+  let a = Array.init size (fun i -> G.register (Int.to_string i))
+
+  let check () =
+    for i = 0 to size - 1 do
+      if G.get a.(i) <> vals.(i) then begin
+        print_string "Error on "; print_int i; print_string ": ";
+        print_string (String.escaped (G.get a.(i))); print_newline()
+      end
+    done
+
+  let change () =
+    match Random.int 37 with
+    | 0 ->
+        Gc.full_major()
+    | 1|2|3|4 ->
+        Gc.minor()
+    | 5|6|7|8|9|10|11|12 ->             (* update with young value *)
+        let i = Random.int size in
+        G.set a.(i) (Int.to_string i)
+    | 13|14|15|16|17|18|19|20 ->        (* update with old value *)
+        let i = Random.int size in
+        G.set a.(i) vals.(i)
+    | 21|22|23|24|25|26|27|28 ->        (* re-register young value *)
+        let i = Random.int size in
+        G.remove a.(i);
+        a.(i) <- G.register (Int.to_string i)
+    | (*29|30|31|32|33|34|35|36*) _ ->  (* re-register old value *)
+        let i = Random.int size in
+        G.remove a.(i);
+        a.(i) <- G.register vals.(i)
+
+  let test n =
+    for _ = 1 to n do
+      change();
+      print_string "."; flush stdout
+    done
+end
+
+module TestClassic = Test(Classic)
+module TestGenerational = Test(Generational)
+
+external young2old : unit -> unit = "gb_young2old"
+external static2young : int * int -> (unit -> unit) -> int = "gb_static2young"

--- a/benchmarks/multicore-gcroots/globroots/globrootsprim.c
+++ b/benchmarks/multicore-gcroots/globroots/globrootsprim.c
@@ -1,0 +1,116 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
+/*                                                                     */
+/*  Copyright 2001 Institut National de Recherche en Informatique et   */
+/*  en Automatique.  All rights reserved.  This file is distributed    */
+/*  under the terms of the GNU Library General Public License, with    */
+/*  the special exception on linking described in file ../LICENSE.     */
+/*                                                                     */
+/***********************************************************************/
+
+/* For testing global root registration */
+
+#define CAML_INTERNALS
+
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+#include "caml/alloc.h"
+#include "caml/gc.h"
+#include "caml/shared_heap.h"
+#include "caml/callback.h"
+
+struct block { value header; value v; };
+
+#define Block_val(v) ((struct block*) &((value*) v)[-1])
+#define Val_block(b) ((value) &((b)->v))
+
+value gb_get(value vblock)
+{
+  return Block_val(vblock)->v;
+}
+
+value gb_classic_register(value v)
+{
+  struct block * b = caml_stat_alloc(sizeof(struct block));
+  b->header = Make_header(1, 0, NOT_MARKABLE);
+  b->v = v;
+  caml_register_global_root(&(b->v));
+  return Val_block(b);
+}
+
+value gb_classic_set(value vblock, value newval)
+{
+  Block_val(vblock)->v = newval;
+  return Val_unit;
+}
+
+value gb_classic_remove(value vblock)
+{
+  caml_remove_global_root(&(Block_val(vblock)->v));
+  return Val_unit;
+}
+
+value gb_generational_register(value v)
+{
+  struct block * b = caml_stat_alloc(sizeof(struct block));
+  b->header = Make_header(1, 0, NOT_MARKABLE);
+  b->v = v;
+  caml_register_generational_global_root(&(b->v));
+  return Val_block(b);
+}
+
+value gb_generational_set(value vblock, value newval)
+{
+  caml_modify_generational_global_root(&(Block_val(vblock)->v), newval);
+  return Val_unit;
+}
+
+value gb_generational_remove(value vblock)
+{
+  caml_remove_generational_global_root(&(Block_val(vblock)->v));
+  return Val_unit;
+}
+
+value root;
+
+value gb_young2old(value _dummy) {
+  root = caml_alloc_small(1, 0);
+  caml_register_generational_global_root(&root);
+  caml_modify_generational_global_root(&root, caml_alloc_shr(10, String_tag));
+  Field(root, 0) = 0xFFFFFFFF;
+  caml_remove_generational_global_root(&root);
+  root += sizeof(value);
+  return Val_unit;
+}
+
+value gb_static2young(value static_value, value full_major) {
+  CAMLparam2 (static_value, full_major);
+  CAMLlocal1(v);
+  int i;
+
+  root = Val_unit;
+  caml_register_generational_global_root(&root);
+
+  /* Write a static value in the root. */
+  caml_modify_generational_global_root(&root, static_value);
+
+  /* Overwrite it with a young value. */
+  v = caml_alloc_small(1, 0);
+  Field(v, 0) = Val_long(0x42);
+  caml_modify_generational_global_root(&root, v);
+
+  /* Promote the young value */
+  caml_callback(full_major, Val_unit);
+
+  /* Fill the minor heap to make sure the old block is overwritten */
+  for(i = 0; i < 1000000; i++)
+    caml_alloc_small(1, 0);
+
+  v = Field(root, 0);
+  caml_remove_generational_global_root(&root);
+
+  CAMLreturn(v);
+}

--- a/benchmarks/multicore-gcroots/globroots_mp.ml
+++ b/benchmarks/multicore-gcroots/globroots_mp.ml
@@ -1,0 +1,18 @@
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
+let n = (try int_of_string Sys.argv.(2) with _ -> 1000) / num_domains
+
+open Globroots
+
+let work () =
+  young2old (); Gc.full_major ();
+  print_string "Non-generational API\n";
+  TestClassic.test n;
+  print_newline();
+  print_string "Generational API\n";
+  TestGenerational.test n;
+  print_newline()
+
+let _ =
+  let domains = Array.init (num_domains - 1) (fun _ -> Domain.spawn(work)) in
+  work ();
+  Array.iter Domain.join domains

--- a/benchmarks/multicore-gcroots/globroots_seq.ml
+++ b/benchmarks/multicore-gcroots/globroots_seq.ml
@@ -1,0 +1,15 @@
+let n = try int_of_string Sys.argv.(2) with _ -> 10000
+open Globroots
+
+let _ = young2old (); Gc.full_major ()
+
+let _ =
+  assert (static2young (1, 1) Gc.full_major == 0x42)
+
+let _ =
+  print_string "Non-generational API\n";
+  TestClassic.test n;
+  print_newline();
+  print_string "Generational API\n";
+  TestGenerational.test n;
+  print_newline()

--- a/benchmarks/multicore-gcroots/globroots_sp.ml
+++ b/benchmarks/multicore-gcroots/globroots_sp.ml
@@ -1,0 +1,25 @@
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
+let n = try int_of_string Sys.argv.(2) with _ -> 1000
+module C = Domainslib.Chan
+
+open Globroots
+
+let c = C.make_bounded 0
+
+let wait () =
+  C.recv c |> ignore
+
+let _ =
+  let domains = Array.init (num_domains - 1) (fun _ -> Domain.spawn(wait)) in
+  young2old (); Gc.full_major ();
+  assert (static2young (1, 1) Gc.full_major == 0x42);
+  print_string "Non-generational API\n";
+  TestClassic.test n;
+  print_newline();
+  print_string "Generational API\n";
+  TestGenerational.test n;
+  print_newline();
+  for i = 1 to (num_domains - 1) do
+    C.send c i
+  done;
+  Array.iter Domain.join domains

--- a/micro_multicore.json
+++ b/micro_multicore.json
@@ -108,7 +108,7 @@
   {
     "executable": "benchmarks/multicore-gcroots/globroots_seq.exe",
     "name": "globroots_seq",
-    "tags": ["lt_1s", "sequential", "parallel"],
+    "tags": ["lt_1s", "parallel"],
     "runs": [
       { "params": "10000" }
     ]

--- a/micro_multicore.json
+++ b/micro_multicore.json
@@ -5,6 +5,10 @@
       "command": "orun -o %{output} -- %{command}"
     },
     {
+      "name": "orunchrt",
+      "command": "orun -o %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+    },
+    {
       "name": "perfstat",
       "command": "perf stat -o %{output} -- %{command}"
     },
@@ -21,7 +25,7 @@
     {
       "executable": "benchmarks/simple-tests/finalise.exe",
       "name": "finalise",
-      "tags": ["lt_1s"],
+      "tags": ["lt_1s", "sequential"],
       "runs": [
         { "params": "10" }
     ]
@@ -29,7 +33,7 @@
   {
       "executable": "benchmarks/simple-tests/finalise.exe",
       "name": "finalise",
-      "tags": ["1s_10s"],
+      "tags": ["1s_10s", "sequential"],
       "runs": [
         { "params": "20" },
         { "params": "30" },
@@ -46,7 +50,7 @@
    {
       "executable": "benchmarks/simple-tests/lazy_primes.exe",
       "name": "lazy_primes",
-      "tags": ["lt_1s"],
+      "tags": ["lt_1s", "sequential"],
       "runs": [
         { "params": "1000" },
         { "params": "2000" },
@@ -56,7 +60,7 @@
      {
       "executable": "benchmarks/simple-tests/lazy_primes.exe",
       "name": "lazy_primes",
-      "tags": ["1s_10s"],
+      "tags": ["1s_10s", "sequential"],
       "runs": [
         { "params": "4000" },
         { "params": "5000" },
@@ -68,7 +72,7 @@
      {
       "executable": "benchmarks/simple-tests/lazy_primes.exe",
       "name": "lazy_primes",
-      "tags": ["10s_100s"],
+      "tags": ["10s_100s", "sequential"],
       "runs": [
         { "params": "9000" },
         { "params": "10000" }
@@ -78,7 +82,7 @@
     {
       "executable": "benchmarks/simple-tests/weakretain.exe",
       "name": "weakretain",
-      "tags": ["1s_10s"],
+      "tags": ["1s_10s", "sequential"],
       "runs": [
         { "params": "25 10000000" },
         { "params": "50 10000000" },
@@ -91,7 +95,7 @@
     {
       "executable": "benchmarks/simple-tests/weakretain.exe",
       "name": "weakretain",
-      "tags": ["lt_1s"],
+      "tags": ["lt_1s", "sequential"],
       "runs": [
       	{ "params": "50 1000" },
         { "params": "50 100000" },
@@ -100,6 +104,44 @@
         { "params": "100 1000" },
         { "params": "75 1000" }
       ]
+  },
+  {
+    "executable": "benchmarks/multicore-gcroots/globroots_seq.exe",
+    "name": "globroots_seq",
+    "tags": ["lt_1s", "sequential", "parallel"],
+    "runs": [
+      { "params": "10000" }
+    ]
+  },
+  {
+    "executable": "benchmarks/multicore-gcroots/globroots_sp.exe",
+    "name": "globroots_sp",
+    "tags": ["parallel"],
+    "runs": [
+      { "params": "1 10000", "paramwrapper": "taskset --cpu-list 2-13"},
+      { "params": "2 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "4 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "8 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "12 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "16 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+      { "params": "20 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+      { "params": "24 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+    ]
+  },
+  {
+    "executable": "benchmarks/multicore-gcroots/globroots_mp.exe",
+    "name": "globroots_mp",
+    "tags": ["parallel"],
+    "runs": [
+      { "params": "1 10000", "paramwrapper": "taskset --cpu-list 2-13"},
+      { "params": "2 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "4 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "8 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "12 10000", "paramwrapper": "taskset --cpu-list 2-13" },
+      { "params": "16 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+      { "params": "20 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+      { "params": "24 10000", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+    ]
   }
   ]
 }


### PR DESCRIPTION
This patch adds a microbenchmark that measures the efficiency of global root scanning. There are three parts:

1. `globroots_seq.ml` - Single core version adapted from [trunk's testsuite](https://github.com/ocaml/ocaml/blob/trunk/testsuite/tests/gc-roots/globroots.ml).
2. `globroots_sp.ml` - Multicore version of (1), where one domain does all the work and other domains are idle waiting on a channel.
3. `globroots_mp.ml` - Modification of (2), work is split equally among the available domains.