### PR TITLE
Fix params for simple-tests/capi

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -782,13 +782,13 @@
       "tags": ["lt_1s"],
       "runs": [
         {
-          "params": "test_many_args_noalloc_200_000_000"
+          "params": "test_many_args_noalloc 200_000_000"
         },
         {
-        	"params":"test_no_args_noalloc_200_000_000"
+          "params":"test_no_args_noalloc 200_000_000"
         },
         {
-        	"params":"test_few_args_noalloc_200_000_000"
+          "params":"test_few_args_noalloc 200_000_000"
         }
     ]
   },


### PR DESCRIPTION
The arguments to `simple-tests/capi` were not being parsed correctly as mentioned in https://github.com/ocaml-bench/sandmark/issues/206, and this PR fixes the same. You can verify using the following commands:
```
$ TAG='"lt_1s"' make run_config_filtered.json
$ RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.10.0+multicore.bench
```