### PR TITLE
Use rule target kronecker.txt and remove from macro_bench

### DIFF
--- a/benchmarks/graph500seq/dune
+++ b/benchmarks/graph500seq/dune
@@ -1,4 +1,16 @@
 (executables
 	(names kronecker kernel1 kernel2 kernel3))
 
-(alias (name buildbench) (deps kronecker.exe kernel1.exe kernel2.exe kernel3.exe))
+
+(rule
+	(targets kronecker.txt)
+	(deps (:prog kronecker.exe))
+	(action (with-stdout-to %{targets} (run %{prog} 12 10))))
+
+(alias
+	(name test1done)
+	(deps kronecker.txt kronecker.exe kernel1.exe))
+
+(alias
+	(name buildbench)
+	(deps (alias test1done) kernel2.exe kernel3.exe))

--- a/run_config.json
+++ b/run_config.json
@@ -22,7 +22,7 @@
       "executable": "benchmarks/graph500seq/kronecker.exe",
       "name": "kronecker",
       "tags": [
-        "10s_100s", "macro_bench"
+        "10s_100s"
       ],
       "runs": [
 	{
@@ -34,7 +34,7 @@
       "executable": "benchmarks/graph500seq/kernel1.exe",
       "name": "kernel1",
       "tags": [
-        "1s_10s", "macro_bench"
+        "1s_10s"
       ],
       "runs": [
 	{
@@ -46,7 +46,7 @@
       "executable": "benchmarks/graph500seq/kernel2.exe",
       "name": "kernel2",
       "tags": [
-        "10s_100s", "macro_bench"
+        "10s_100s"
       ],
       "runs": [
 	{


### PR DESCRIPTION
The graph500seq benchmarks were failing because of `kronecker.txt: No such file or directory` as mentioned at https://github.com/ocaml-bench/sandmark/issues/207. This PR
* Uses a target rule to build kronecker.txt before running `kernel2` and `kernel3`.
* Removes graph500seq benchmarks from `macro_bench` tag.
