### PR TITLE
don't share array in global roots parallel benchmarks

### DIFF
--- a/benchmarks/multicore-gcroots/globroots/globroots.ml
+++ b/benchmarks/multicore-gcroots/globroots/globroots.ml
@@ -26,6 +26,8 @@ module Test(G: GLOBREF) () = struct
 
   let size = 1024
 
+  let random_state = Domain.DLS.new_key Random.State.make_self_init
+
   let vals = Array.init size Int.to_string
 
   let a = Array.init size (fun i -> G.register (Int.to_string i))
@@ -39,23 +41,23 @@ module Test(G: GLOBREF) () = struct
     done
 
   let change () =
-    match Random.int 37 with
+    match Random.State.int (Domain.DLS.get random_state) 37 with
     | 0 ->
         Gc.full_major()
     | 1|2|3|4 ->
         Gc.minor()
     | 5|6|7|8|9|10|11|12 ->             (* update with young value *)
-        let i = Random.int size in
+        let i = Random.State.int (Domain.DLS.get random_state) size in
         G.set a.(i) (Int.to_string i)
     | 13|14|15|16|17|18|19|20 ->        (* update with old value *)
-        let i = Random.int size in
+        let i = Random.State.int (Domain.DLS.get random_state) size in
         G.set a.(i) vals.(i)
     | 21|22|23|24|25|26|27|28 ->        (* re-register young value *)
-        let i = Random.int size in
+        let i = Random.State.int (Domain.DLS.get random_state) size in
         G.remove a.(i);
         a.(i) <- G.register (Int.to_string i)
     | (*29|30|31|32|33|34|35|36*) _ ->  (* re-register old value *)
-        let i = Random.int size in
+        let i = Random.State.int (Domain.DLS.get random_state) size in
         G.remove a.(i);
         a.(i) <- G.register vals.(i)
 

--- a/benchmarks/multicore-gcroots/globroots/globroots.ml
+++ b/benchmarks/multicore-gcroots/globroots/globroots.ml
@@ -22,7 +22,7 @@ module Generational : GLOBREF = struct
   external remove: t -> unit = "gb_generational_remove"
 end
 
-module Test(G: GLOBREF) = struct
+module Test(G: GLOBREF) () = struct
 
   let size = 1024
 
@@ -65,9 +65,6 @@ module Test(G: GLOBREF) = struct
       print_string "."; flush stdout
     done
 end
-
-module TestClassic = Test(Classic)
-module TestGenerational = Test(Generational)
 
 external young2old : unit -> unit = "gb_young2old"
 external static2young : int * int -> (unit -> unit) -> int = "gb_static2young"

--- a/benchmarks/multicore-gcroots/globroots_mp.ml
+++ b/benchmarks/multicore-gcroots/globroots_mp.ml
@@ -4,6 +4,8 @@ let n = (try int_of_string Sys.argv.(2) with _ -> 1000) / num_domains
 open Globroots
 
 let work () =
+  let module TestClassic = Test(Classic) () in
+  let module TestGenerational = Test(Generational) () in
   young2old (); Gc.full_major ();
   print_string "Non-generational API\n";
   TestClassic.test n;

--- a/benchmarks/multicore-gcroots/globroots_seq.ml
+++ b/benchmarks/multicore-gcroots/globroots_seq.ml
@@ -1,6 +1,9 @@
 let n = try int_of_string Sys.argv.(2) with _ -> 10000
 open Globroots
 
+module TestClassic = Test(Classic) ()
+module TestGenerational = Test(Generational) ()
+
 let _ = young2old (); Gc.full_major ()
 
 let _ =

--- a/benchmarks/multicore-gcroots/globroots_sp.ml
+++ b/benchmarks/multicore-gcroots/globroots_sp.ml
@@ -4,6 +4,9 @@ module C = Domainslib.Chan
 
 open Globroots
 
+module TestClassic = Test(Classic) ()
+module TestGenerational = Test(Generational) ()
+
 let c = C.make_bounded 0
 
 let wait () =


### PR DESCRIPTION
Similar to https://github.com/ocaml-multicore/ocaml-multicore/pull/481