### PR TITLE
Remove Gc.promote_to from treiber_stack.ml

### DIFF
--- a/benchmarks/multicore-structures/treiber_stack.ml
+++ b/benchmarks/multicore-structures/treiber_stack.ml
@@ -11,7 +11,6 @@ let rec add_node s n =
 
 let push s x =
   let new_node = {value= x; next= Atomic.make None} in
-  Gc.promote_to new_node s |> ignore ;
   add_node s new_node
 
 let rec remove_node s =


### PR DESCRIPTION
4.12+domains removes Gc.promote_to from the runtime ([multicore#489](https://github.com/ocaml-multicore/ocaml-multicore/pull/489)). 

Treiber stack was using the function mentioned above and it might break multicore-structures benchmark when sandmark moves to 4.12+domains and 4.12+domains+effects.

I've tested with domains+effects branch it seems to work without any issue.

I need to check the performance numbers of the benchmarks in multicore-strcutures which use `treiber_stack.ml` and see if there are any difference with this change. 