### PR TITLE
Fix up decompress iterations of work

### DIFF
--- a/benchmarks/decompress/dune
+++ b/benchmarks/decompress/dune
@@ -6,7 +6,7 @@
 (executable
  (name test_decompress_multicore)
   (modules test_decompress_multicore)
-  (libraries bigstringaf checkseum.ocaml decompress.zl))
+  (libraries bigstringaf checkseum.ocaml decompress.zl domainslib))
 
 (alias (name buildbench)
        (deps test_decompress.exe))

--- a/benchmarks/decompress/test_decompress.ml
+++ b/benchmarks/decompress/test_decompress.ml
@@ -55,7 +55,7 @@ let uncompress data =
     let len =
       (min : int -> int -> int) (Bigstringaf.length v) (String.length data - !p) in
     Bigstringaf.blit_from_string
-      data ~src_off:!p 
+      data ~src_off:!p
       v ~dst_off:0 ~len ; p := !p + len ; len in
   let flush v len = blit_to_buffer t b v len in
 
@@ -64,15 +64,15 @@ let uncompress data =
 let () = Random.init(42)
 
 let data_to_compress =
-  let buf = Bytes.create data_size in
-  for i = 0 to data_size - 1 do
-    Bytes.set buf i (Char.chr (97 + Random.int 26))
-  done ;
-  Bytes.to_string buf
+  let fn _ = Char.chr (97 + Random.int 26) in
+  String.init data_size fn
 
 let () =
-  for run = 0 to iterations do
+  let iter_count = ref 0 in
+  for run = 1 to iterations do
     let result = compress data_to_compress in
     let original = uncompress result in
-    ignore original
-  done
+    ignore original;
+    incr iter_count
+  done;
+  assert (!iter_count = iterations)


### PR DESCRIPTION
This PR fixes errors between the amount of work configured and the amount of work done. 

The changes are:
- fix up for indices and explicitly count the amount of work done with an assert that the work done is the work requested. (consider `iterations=4` & `num_domains=2`, in this configuration I make there being _3_ units of work being done by each of the domains and not 2 in the existing code).
- moves the multicore test to use a pool with `parallel_for`; this is important as there are unintended consequences in the existing code (consider `iterations=3` & `num_domains=4`, it will distribute `work 0` to the first three spawned domains and then do 3 units of work in the final domain).
- simplifies the `data_to_compress` setup to use `String.init` which is more idiomatic.
