### PR TITLE
A better floyd warshall

### DIFF
--- a/benchmarks/multicore-numerical/floyd_warshall.ml
+++ b/benchmarks/multicore-numerical/floyd_warshall.ml
@@ -1,58 +1,57 @@
 let n = try int_of_string Sys.argv.(1) with _ -> 4
 
-type e =
-      | None
-      | Some of int
-
-let sum x y =
-  match x , y with
-  | Some x ,Some y -> Some (x+y)
-  | _ , _-> None
+type edge =
+  | Infinity
+  | Value of int
 
 let print_inf x =
   match  x with
-  | Some x -> print_int x
-  | None -> print_string "∞"
+  | Value x -> print_int x
+  | Infinity -> print_string "∞"
 
+let print_mat adjacency =
+  print_endline " ";
+  let rows = Array.length adjacency in
+  let columns = Array.length adjacency.(0) in
+  for i = 0 to (rows - 1) do
+    for j = 0 to (columns - 1) do
+      print_inf adjacency.(i).(j); print_string " "
+    done;
+    print_endline " "
+  done
 
-let my_formula () =
-  let r = Random.int 100 in
-  let r1 = Random.int 2 in
-  match r1 with
-  |0 ->None
-  |_-> Some r
-
-
-let adj = Array.init n (fun _ -> Array.init n (fun _ -> my_formula ()))
-
-let edit_diagonal mat =
-  Array.iteri (fun i _ -> mat.(i).(i) <- Some 0) mat
-
+(* setup the adjacency matrix for the test *)
+let make_adj n =
+  let random_init _i =
+    match Random.int 2 with
+    | 0 -> Infinity
+    | _ -> Value (Random.int 100) in
+  let mat = Array.init n (fun _ -> Array.init n random_init) in
+  (* zero the diagonal *)
+  for i = 0 to (n-1) do
+    mat.(i).(i) <- Value 0
+  done;
+  mat
 
 let f_w adj =
   for k = 0 to n-1 do
     for i = 0 to n-1 do
-      if adj.(i).(k) <> None then
+      match adj.(i).(k) with
+      | Value a_ik ->
         for j = 0 to n-1 do
-          if adj.(k).(j) <> None && (adj.(i).(j) = None || ( sum  adj.(i).(k)   adj.(k).(j) ) <  adj.(i).(j) ) then
-            adj.(i).(j) <- (sum adj.(i).(k)  adj.(k).(j))
+          match adj.(i).(j), adj.(k).(j) with
+            | Infinity, Value a_kj ->
+              adj.(i).(j) <- Value (a_ik + a_kj)
+            | Value a_ij, Value a_kj when a_ik + a_kj < a_ij ->
+              adj.(i).(j) <- Value (a_ik + a_kj)
+            | _, _ -> ()
         done
+      | Infinity -> ()
     done
   done
 
-let print_mat adjacency =
-print_endline " ";
-let rows = Array.length adjacency in
-let columns = Array.length adjacency.(0) in
-   for i = 0 to (rows - 1) do
-       for j = 0 to (columns - 1) do
-           print_inf adjacency.(i).(j); print_string " "
-       done;
-       print_endline " "
-   done
-
-
-let ()=
-  edit_diagonal adj;
+let () =
+  Random.init 512;
+  let adj = make_adj n in
   f_w adj
  (* print_mat adj*)

--- a/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
+++ b/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
@@ -1,68 +1,74 @@
+module T = Domainslib.Task
+
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let n = try int_of_string Sys.argv.(2) with _ -> 4
 (* n is size of matrix  *)
 
-let sum x y =
-  match x , y with
-  | Some x ,Some y -> Some (x+y)
-  | _ , _-> None
+type edge =
+  | Infinity
+  | Value of int
 
 let print_inf x =
   match  x with
-  | Some x -> print_int x
-  | None -> print_string "∞"
+  | Value x -> print_int x
+  | Infinity -> print_string "∞"
 
 let print_mat adjacency =
-print_endline " ";
-let rows = Array.length adjacency in
-let columns = Array.length adjacency.(0) in
-   for i = 0 to (rows - 1) do
-       for j = 0 to (columns - 1) do
-           print_inf adjacency.(i).(j); print_string " "
-       done;
-       print_endline " "
-   done
+  print_endline " ";
+  let rows = Array.length adjacency in
+  let columns = Array.length adjacency.(0) in
+  for i = 0 to (rows - 1) do
+    for j = 0 to (columns - 1) do
+      print_inf adjacency.(i).(j); print_string " "
+    done;
+    print_endline " "
+  done
 
-module T = Domainslib.Task
+(* setup the adjacency matrix for the test *)
+let make_adj n =
+  let random_init _i =
+    match Random.int 2 with
+    | 0 -> Infinity
+    | _ -> Value (Random.int 100) in
+  let mat = Array.init n (fun _ -> Array.init n random_init) in
+  (* zero the diagonal *)
+  for i = 0 to (n-1) do
+    mat.(i).(i) <- Value 0
+  done;
+  mat
 
-let my_formula () =
-  let r = Random.int 100 in
-  let r1 = Random.int 2 in
-  match r1 with
-  |0 ->None
-  |_-> Some r
-
-let adj = Array.init n (fun _ -> Array.init n (fun _ -> my_formula ()))
-
-let edit_diagonal mat =
-  Array.iteri (fun i _ -> mat.(i).(i) <- Some 0) mat
-
-(* let adj = [|
-    [| Some 0; Some 8;None; Some 1 |];
-    [| None; Some 0; Some 1; None|];
-    [| Some 4;None;Some 0;None |];
-    [| None; Some 2; Some 9;Some 0 |];
-  |] *)
-
-let aux pool =
-  for k = 0 to (pred n) do
+let f_w pool adj =
+  for k = 0 to (n-1) do
     T.parallel_for pool
     ~start:0
     ~finish:(n - 1)
     ~body:(fun i ->
-      if adj.(i).(k) <> None then
+      match adj.(i).(k) with
+      | Value a_ik ->
         for j = 0 to n-1 do
-          Domain.Sync.poll();
-            if adj.(k).(j) <> None
-              && (adj.(i).(j) = None
-              || (sum adj.(i).(k) adj.(k).(j)) <  adj.(i).(j))
-            then adj.(i).(j) <- (sum adj.(i).(k)  adj.(k).(j))
-        done);
+          match adj.(i).(j), adj.(k).(j) with
+            | Infinity, Value a_kj ->
+              adj.(i).(j) <- Value (a_ik + a_kj)
+            | Value a_ij, Value a_kj when a_ik + a_kj < a_ij ->
+              adj.(i).(j) <- Value (a_ik + a_kj)
+            | _, _ -> Domain.Sync.poll()
+        done
+      | Infinity -> Domain.Sync.poll()
+      );
   done
 
 let ()=
+  Random.init 512;
+  let adj = make_adj n in
   let pool = T.setup_pool ~num_domains:(num_domains - 1) in
-  edit_diagonal adj;
-  aux pool;
+  (*
+  let adj = [|
+    [| Value 0; Value 8; Infinity; Value 1 |];
+    [| Infinity; Value 0; Value 1; Infinity|];
+    [| Value 4; Infinity; Value 0; Infinity |];
+    [| Infinity; Value 2; Value 9; Value 0 |];
+  |] in
+  *)
+  f_w pool adj;
   (* print_mat adj ; *)
   T.teardown_pool pool


### PR DESCRIPTION
This PR attempts to improve the floyd warshall benchmark. 

It does this by:
 - being a bit clearer about the meaning of the edges (`Infinity | Value of int` vs `None | Some of int`)
 - fixing the random seed so that runs are repeatable
 - avoiding polymorphic compare and making the branches a bit easier to inspect via pattern matching (which also avoids needing a `sum` function)

Over all this improves the performance of the benchmark (untuned Zen2 machine):
![20210507_fw_speed](https://user-images.githubusercontent.com/1682628/117497861-ebab4480-af70-11eb-9e94-86fc7d3825df.png)
![20210507_fw_speedup](https://user-images.githubusercontent.com/1682628/117497866-eea63500-af70-11eb-916c-24c4032856cb.png)
![20210507_fw_minorgc](https://user-images.githubusercontent.com/1682628/117497875-f1a12580-af70-11eb-8ee7-4d7d9d28b207.png)

