### PR TITLE
Some improvements for matrix multiplication

### DIFF
--- a/benchmarks/multicore-numerical/matrix_multiplication.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication.ml
@@ -1,14 +1,26 @@
 let size = try int_of_string Sys.argv.(1) with _ -> 1024
 
-let matrix_multiply z x y =
-  let lx = Array.length x in
-  let ly = Array.length y in
-  for i = 0 to lx - 1 do
-    for j = 0 to ly - 1 do
-      for k = 0 to ly - 1 do
-        z.(i).(j) <- z.(i).(j) + x.(i).(k) * y.(k).(j)
-      done
+let matrix_multiply res x y =
+  let i_n = Array.length x in
+  let j_n = Array.length y.(0) in
+  let k_n = Array.length y in
+
+  for i = 0 to i_n - 1 do
+    for j = 0 to j_n - 1 do
+      let w = ref 0 in
+      for k = 0 to k_n - 1 do
+        w := !w + x.(i).(k) * y.(k).(j);
+      done;
+      res.(i).(j) <- !w
     done
+  done
+
+let print_matrix m =
+  for i = 0 to pred (Array.length m) do
+    for j = 0 to pred (Array.length m.(0)) do
+      print_string @@ Printf.sprintf " %d " m.(i).(j)
+    done;
+    print_endline "";
   done
 
 let () =
@@ -16,10 +28,7 @@ let () =
   let m1 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in
   let m2 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in
   let res = Array.make_matrix size size 0 in
+
   matrix_multiply res m1 m2;
-  for i = 0 to size - 1 do
-    for j = 0 to size - 1 do
-      print_int res.(i).(j); print_string "  "
-    done;
-    print_newline()
-  done
+
+  (* print_matrix res; *)

--- a/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
@@ -1,35 +1,38 @@
 module T = Domainslib.Task
 
 let num_domains = try Sys.argv.(1) |> int_of_string with _ -> 1
-let n = try Sys.argv.(2) |> int_of_string with _ -> 1024
-let pool = T.setup_pool ~num_domains:(num_domains - 1)
-let m3 = Array.make_matrix n n 0
+let size = try Sys.argv.(2) |> int_of_string with _ -> 1024
 
-let mat_mul m1 m2 =
-  let i_n = Array.length m1 in
-  let j_n = Array.length m2.(0) in
-  let k_n = Array.length m2 in
+let matrix_multiply pool res x y =
+  let i_n = Array.length x in
+  let j_n = Array.length y.(0) in
+  let k_n = Array.length y in
 
   T.parallel_for pool ~start:0 ~finish:(i_n - 1) ~body:(fun i ->
-    for j = 0 to pred j_n do
-      for k = 0 to pred k_n do
-        m3.(i).(j) <- m3.(i).(j) + (m1.(i).(k) * m2.(k).(j));
+    for j = 0 to j_n -1 do
+      let w = ref 0 in
+      for k = 0 to k_n - 1 do
+        w := !w + x.(i).(k) * y.(k).(j);
       done;
+      res.(i).(j) <- !w
     done)
 
-(* let print_matrix m =
+let print_matrix m =
   for i = 0 to pred (Array.length m) do
     for j = 0 to pred (Array.length m.(0)) do
       print_string @@ Printf.sprintf " %d " m.(i).(j)
     done;
     print_endline "";
-  done *)
+  done
 
 let _ =
-    let m1 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
-    let m2 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
-    (* print_matrix m1;
-    print_matrix m2; *)
-    mat_mul m1 m2;
+    let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+
+    let m1 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in
+    let m2 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in
+    let res = Array.make_matrix size size 0 in
+
+    (* print_matrix m1; print_matrix m2; *)
+    matrix_multiply pool res m1 m2;
     T.teardown_pool pool;
-    (* print_matrix m3; *)
+    (* print_matrix res; *)


### PR DESCRIPTION
This PR makes small improvements to the efficiency and scaling of our multicore matrix multiplication benchmark. 

The changes are:
- bring `matrix_multiplication` and `matrix_multiplication_multicore` more into line with each other to make things a bit easier to maintain
- avoid writing the results matrix until we have summed the values for the element; this technique was effective with nbody and it is effective here. 

Rough and ready benchmark results on a Zen2 machine (detuned):
![20210510_mat_mult_time](https://user-images.githubusercontent.com/1682628/117686618-f18e6900-b1ae-11eb-8845-1ef474eaa7a7.png)
![20210510_mat_mult_speedup](https://user-images.githubusercontent.com/1682628/117686625-f3f0c300-b1ae-11eb-902d-ba2068455f31.png)
