### PR TITLE
Improve `nbody_multicore` benchmark with high core counts

### DIFF
--- a/benchmarks/multicore-numerical/nbody_multicore.ml
+++ b/benchmarks/multicore-numerical/nbody_multicore.ml
@@ -18,7 +18,7 @@ type planet = { mutable x : float;  mutable y : float;  mutable z : float;
                 mutable vx: float;  mutable vy: float;  mutable vz: float;
                 mass : float }
 
-let aux_1 bodies dt pool =
+let advance pool bodies dt =
   T.parallel_for pool
     ~start:0
     ~finish:(num_bodies - 1)
@@ -48,26 +48,29 @@ let aux_1 bodies dt pool =
     b.z <- b.z +. dt *. b.vz;
   done
 
-let energy bodies =
-  let e = ref 0. in
-  for i = 0 to Array.length bodies - 1 do
-    let b = bodies.(i) in
-    e := !e +. 0.5 *. b.mass *. (b.vx *. b.vx +. b.vy *. b.vy +. b.vz *. b.vz);
-    for j = i+1 to Array.length bodies - 1 do
-      let b' = bodies.(j) in
-      let dx = b.x -. b'.x  and dy = b.y -. b'.y  and dz = b.z -. b'.z in
-      let distance = sqrt(dx *. dx +. dy *. dy +. dz *. dz) in
-      e := !e -. (b.mass *. b'.mass) /. distance
-    done
-  done;
-  !e
+let energy pool bodies =
+  T.parallel_for_reduce pool (+.) 0.
+    ~start:0
+    ~finish:(Array.length bodies -1)
+    ~body:(fun i ->
+      let b = bodies.(i) and e = ref 0. in
+      e := !e +. 0.5 *. b.mass *. (b.vx *. b.vx +. b.vy *. b.vy +. b.vz *. b.vz);
+      for j = i+1 to Array.length bodies - 1 do
+        let b' = bodies.(j) in
+        let dx = b.x -. b'.x  and dy = b.y -. b'.y  and dz = b.z -. b'.z in
+        let distance = sqrt(dx *. dx +. dy *. dy +. dz *. dz) in
+        e := !e -. (b.mass *. b'.mass) /. distance;
+        Domain.Sync.poll ()
+      done;
+      !e)
 
 let offset_momentum bodies =
   let px = ref 0. and py = ref 0. and pz = ref 0. in
   for i = 0 to Array.length bodies - 1 do
-    px := !px +. bodies.(i).vx *. bodies.(i).mass;
-    py := !py +. bodies.(i).vy *. bodies.(i).mass;
-    pz := !pz +. bodies.(i).vz *. bodies.(i).mass;
+    let b = bodies.(i) in
+    px := !px +. b.vx *. b.mass;
+    py := !py +. b.vy *. b.mass;
+    pz := !pz +. b.vz *. b.mass;
   done;
   bodies.(0).vx <- -. !px /. solar_mass;
   bodies.(0).vy <- -. !py /. solar_mass;
@@ -86,7 +89,7 @@ let bodies =
 let () =
   let pool = T.setup_pool ~num_domains:(num_domains - 1) in
   offset_momentum bodies;
-  Printf.printf "%.9f\n" (energy bodies);
-  for _i = 1 to n do aux_1 bodies 0.01 pool done;
-  Printf.printf "%.9f\n" (energy bodies);
+  Printf.printf "%.9f\n" (energy pool bodies);
+  for _i = 1 to n do advance pool bodies 0.01 done;
+  Printf.printf "%.9f\n" (energy pool bodies);
   T.teardown_pool pool


### PR DESCRIPTION
This PR improves `nbody_multicore` with large core counts, by also parallelising the `energy` function with `parallel_for_reduce`.

Benchmark results with higher core counts and bigger instances:
![20210518_nbody_big_time](https://user-images.githubusercontent.com/1682628/118691074-9e489600-b800-11eb-8faa-354b4bd9178c.png)
![20210518_nbody_big_speedup](https://user-images.githubusercontent.com/1682628/118691087-a0125980-b800-11eb-8bc5-f74b233e16c6.png)
