### PR TITLE
make the dune 2.8.1 package use the system dune

### DIFF
--- a/dependencies/packages/dune/dune.2.8.1/opam
+++ b/dependencies/packages/dune/dune.2.8.1/opam
@@ -37,9 +37,9 @@ conflicts: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
-  ["ocaml" "bootstrap.ml" "-j" jobs]
-  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+  # ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  #["ocaml" "bootstrap.ml" "-j" jobs]
+  # ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
@@ -47,6 +47,14 @@ depends: [
   ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
+]
+# HACK: link out to a system dune installation setup in the master makefile
+# This was done as a workaround for dune breakage with trunk until better
+# solutions arrive
+install: [
+  ["ln" "-s" "%{root}%/sys_dune/bin/dune" "%{bin}%/dune"]
+  ["ln" "-s" "%{root}%/sys_dune/bin/jbuilder" "%{bin}%/jbuilder"]
+  ["ln" "-s" "%{root}%/sys_dune/lib/dune" "%{lib}%/dune"]
 ]
 x-commit-hash: "b796156167490e777131403f651e83779e954000"
 url {


### PR DESCRIPTION
It looks like while dune 2.6.0 uses the system dune, the recently introduced 2.8.1 does not.

This fixes breakage when running sandmark on trunk.

