### PR TITLE
[WIP] Build for 4.13.0+trunk with dune.2.8.1

### DIFF
--- a/dependencies/packages/dune-private-libs/dune-private-libs.2.8.1/opam
+++ b/dependencies/packages/dune-private-libs/dune-private-libs.2.8.1/opam
@@ -1,14 +1,13 @@
 opam-version: "2.0"
-synopsis: "Helper library for gathering system configuration"
+synopsis: "Private libraries of Dune"
 description: """
-dune-configurator is a small library that helps writing OCaml scripts that
-test features available on the system, in order to generate config.h
-files for instance.
-Among other things, dune-configurator allows one to:
-- test if a C program compiles
-- query pkg-config
-- import #define from OCaml header files
-- generate config.h file
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
 """
 maintainer: ["Jane Street Group, LLC"]
 authors: ["Jane Street Group, LLC"]
@@ -18,9 +17,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.03.0"}
-  "result"
-  "csexp" {>= "1.3.0"}
+  "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/dependencies/packages/dune/dune.2.8.1/opam
+++ b/dependencies/packages/dune/dune.2.8.1/opam
@@ -19,8 +19,8 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free.
 """
-maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+maintainer: ["Jane Street Group, LLC"]
+authors: ["Jane Street Group, LLC"]
 license: "MIT"
 homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
@@ -37,9 +37,9 @@ conflicts: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
   # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
-  ["ocaml" "bootstrap.ml" "-j" jobs]
-  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+#  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+#  ["ocaml" "bootstrap.ml" "-j" jobs]
+#  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
@@ -47,6 +47,14 @@ depends: [
   ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
+]
+# HACK: link out to a system dune installation setup in the master makefile
+# This was done as a workaround for dune breakage with trunk until better
+# solutions arrive
+install: [
+  ["ln" "-s" "%{root}%/sys_dune/bin/dune" "%{bin}%/dune"]
+  ["ln" "-s" "%{root}%/sys_dune/bin/jbuilder" "%{bin}%/jbuilder"]
+  ["ln" "-s" "%{root}%/sys_dune/lib/dune" "%{lib}%/dune"]
 ]
 x-commit-hash: "b796156167490e777131403f651e83779e954000"
 url {

--- a/dependencies/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0+stock/opam
+++ b/dependencies/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0+stock/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.02.3" & < "4.13"}
+  "ocaml" {>= "4.02.3"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/dependencies/packages/ocamlfind/ocamlfind.1.9.1/opam
+++ b/dependencies/packages/ocamlfind/ocamlfind.1.9.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.
+"""
+license: "MIT"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+depends: [
+  "ocaml" {>= "4.00.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+url {
+  src: "http://download.camlcity.org/download/findlib-1.9.1.tar.gz"
+  checksum: [
+    "md5=65e6dc9b305ccbed1267275fe180f538"
+    "sha512=83a05f3e310fa7cabb0475c5525f7a87c1b6bc2dc5e39f094cabfb5d944a826a5581844ba00ec1a48dd96184eb9de3c4d1055cdddee2b83c700a2de5a6dc6f84"
+  ]
+}

--- a/dependencies/packages/ppxlib/ppxlib.0.22.0+stock/opam
+++ b/dependencies/packages/ppxlib/ppxlib.0.22.0+stock/opam
@@ -20,7 +20,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "4.13"}
+  "ocaml" {>= "4.04.1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}


### PR DESCRIPTION
The dependency packages have been updated to build 4.13.0+trunk with locally installed dune.2.8.1. This builds at least 56 of the macro benchmarks using:
```
TAG='"macro_bench"' make run_config_filtered.json
RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.13.0+trunk.bench
```