### PR TITLE
Remove macro_bench from graph500

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -42,7 +42,7 @@
       "executable": "benchmarks/graph500seq/kronecker.exe",
       "name": "kronecker",
       "tags": [
-        "10s_100s", "macro_bench"
+        "10s_100s"
       ],
       "runs": [
 	{
@@ -54,7 +54,7 @@
       "executable": "benchmarks/graph500seq/kernel1.exe",
       "name": "kernel1",
       "tags": [
-        "1s_10s", "macro_bench"
+        "1s_10s"
       ],
       "runs": [
 	{
@@ -66,7 +66,7 @@
       "executable": "benchmarks/graph500seq/kernel2.exe",
       "name": "kernel2",
       "tags": [
-        "10s_100s", "macro_bench"
+        "10s_100s"
       ],
       "runs": [
 	{
@@ -78,7 +78,7 @@
       "executable": "benchmarks/graph500seq/kernel3.exe",
       "name": "kernel3",
       "tags": [
-        "10s_100s", "macro_bench"
+        "10s_100s"
       ],
       "runs": [
 	{


### PR DESCRIPTION
Remove the `macro_bench` tag from graph500 benchmarks as they are outliers skewing benchmark results and need to be re-implemented.