### PR TITLE
Port grammatrix to Task pool

### DIFF
--- a/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
+++ b/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
@@ -26,11 +26,16 @@ let dot_product xs ys =
 let compute_gram_matrix samples pool res =
   let n = A.length samples in
   assert(n > 0);
-  T.parallel_for ~start:0 ~finish:(n - 1) ~body:(fun i ->
+  T.parallel_for ~start:0 ~finish:((n - 1)/2) ~body:(fun i ->
     for j = i to n - 1 do
       let x = dot_product samples.(i) samples.(j) in
       res.(i).(j) <- x;
       res.(j).(i) <- x (* symmetric matrix *)
+    done;
+    for j = (n - 1 - i) to (n - 1) do
+      let x = dot_product samples.(n - 1 - i) samples.(j) in
+      res.(n - 1 - i).(j) <- x;
+      res.(j).(n - 1 - i) <- x (* symmetric matrix *)
     done) pool;
   res
 

--- a/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
+++ b/benchmarks/multicore-grammatrix/grammatrix_multicore.ml
@@ -23,10 +23,9 @@ let dot_product xs ys =
   done;
   !res
 
-let compute_gram_matrix samples pool =
+let compute_gram_matrix samples pool res =
   let n = A.length samples in
   assert(n > 0);
-  let res = A.init n (fun _ -> A.create_float n) in
   T.parallel_for ~start:0 ~finish:(n - 1) ~body:(fun i ->
     for j = i to n - 1 do
       let x = dot_product samples.(i) samples.(j) in
@@ -45,9 +44,12 @@ let parse_line line =
   res
 
 let _ =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let samples = A.of_list (Utls.map_on_lines_of_file input_fn parse_line) in
   Printf.printf "samples: %d features: %d\n"
       (A.length samples) (A.length samples.(0));
-  let r = compute_gram_matrix samples pool in
-  Utls.print_matrix r
+  let n = A.length samples in
+  let res = A.init n (fun _ -> A.create_float n) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let r = compute_gram_matrix samples pool res in
+  Utls.print_matrix r;
+  T.teardown_pool pool


### PR DESCRIPTION
This patch moves the multicore grammatrix benchmark to Domainslib Task pool.

Results for different chunk sizes of `parallel_for`, 0 being the default chunk size. Old indicates the handwritten version currently in sandmark.
![image](https://user-images.githubusercontent.com/13328130/122007993-2ad17e80-cdd6-11eb-86f1-f5b67a716907.png)
