### PR TITLE
Switch to default Random module

### DIFF
--- a/benchmarks/multicore-lockfree/test_bag_multicore.ml
+++ b/benchmarks/multicore-lockfree/test_bag_multicore.ml
@@ -6,19 +6,17 @@ let entries_per_dom = num_entries / num_domains
 module Bag = Lockfree.Bag
 
 let bag = Bag.create ()
-let k = Domain.DLS.new_key Random.State.make_self_init
 
 let add_or_remove_entries n () =
-  let state = Domain.DLS.get k in
   for _ = 1 to n do
-  let r = Random.State.int state 100 in
+  let r = Random.int 100 in
   if (r > read_percent) then
-    Bag.push bag (Random.State.int state n)
-  else 
+    Bag.push bag (Random.int n)
+  else
     Bag.pop bag |> ignore
   done
-  
-let _ = 
+
+let _ =
   let d = Array.init (num_domains - 1) (fun _ -> Domain.spawn(add_or_remove_entries entries_per_dom)) in
   add_or_remove_entries entries_per_dom ();
   Array.iter Domain.join d

--- a/benchmarks/multicore-lockfree/test_hash_multicore.ml
+++ b/benchmarks/multicore-lockfree/test_hash_multicore.ml
@@ -9,19 +9,17 @@ module Hash = Lockfree.Hash_Custom(struct
   let hash_function i = i;;
 end)
 
-let k = Domain.DLS.new_key Random.State.make_self_init
 
 let add_or_remove_entries ht n () =
-  let state = Domain.DLS.get k in
-  for i = 1 to n do 
-    let r = Random.State.int state 100 in
-    let key = Random.State.int state n in
+  for i = 1 to n do
+    let r = Random.int 100 in
+    let key = Random.int n in
     if (r > read_percent) then
       Hash.add ht key i
     else
       Hash.find ht key |> ignore
     done
-    
+
 let () =
   let ht = Hash.create () in
   let d = Array.init (num_domains - 1) (fun _ -> Domain.spawn(add_or_remove_entries ht entries_per_dom)) in

--- a/benchmarks/multicore-lockfree/test_list_multicore.ml
+++ b/benchmarks/multicore-lockfree/test_list_multicore.ml
@@ -4,13 +4,11 @@ let read_percent = try int_of_string Sys.argv.(3) with _ -> 50
 let items_per_dom = n / num_domain
 
 module List = Lockfree.List
-let k = Domain.DLS.new_key Random.State.make_self_init
 let l = List.create ()
 
 let push_or_pop n () =
-  let state = Domain.DLS.get k in
   for i = 1 to n do
-    let r = Random.State.int state 100 in
+    let r = Random.int 100 in
     if (r > read_percent) then
       List.push l i
     else

--- a/benchmarks/multicore-lockfree/test_msqueue_multicore.ml
+++ b/benchmarks/multicore-lockfree/test_msqueue_multicore.ml
@@ -1,16 +1,13 @@
 module Msqueue = Lockfree.MSQueue
 
-let num_domains = try int_of_string Sys.argv.(1) with _ -> 4 
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
 let num_items = try int_of_string Sys.argv.(2) with _ -> 10000000
 let read_percent = try int_of_string Sys.argv.(3) with _ -> 50
 let items_per_domain = num_items / num_domains
 
-let k = Domain.DLS.new_key Random.State.make_self_init 
-
 let enqueue_or_dequeue msq n () =
-  let state = Domain.DLS.get k in
   for i = 1 to n do
-    let r = Random.State.int state 100 in
+    let r = Random.int 100 in
     if (r > read_percent) then
       Msqueue.push msq i
     else

--- a/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
+++ b/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
@@ -2,8 +2,6 @@ module T = Domainslib.Task
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let mat_size = try int_of_string Sys.argv.(2) with _ -> 1200
 
-let k = Domain.DLS.new_key Random.State.make_self_init
-
 module SquareMatrix = struct
 
   let create f : float array =
@@ -56,7 +54,7 @@ let lup pool (a0 : float array) =
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let a = parallel_create pool
-    (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
+    (fun _ _ -> (Random.float 100.0) +. 1.0 ) in
   let lu = lup pool a in
   let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
   let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in


### PR DESCRIPTION
Default Random module stores its state in Domain-local storage (see https://github.com/ocaml-multicore/ocaml-multicore/pull/582), thereby making it convenient to be called from multiple domains. Retaining `Random.State` in minilight which uses `Random.State` in the sequential version, global roots micro benchmarks and evolutionary algorithm.