### PR TITLE
add chrt to pausetimes_multicore wrapper

### DIFF
--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes_multicore",
-      "command": "bash pausetimes_multicore %{output} %{paramwrapper} %{command}"
+      "command": "bash pausetimes_multicore %{output} -- %{paramwrapper} chrt -r 1 %{command}"
     }
   ],
   "benchmarks": [

--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "orunchrt",
-      "command": "orun -o %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+      "command": "orun -o %{output} -- %{paramwrapper} chrt -r 1 %{command}"
     },
     {
       "name": "perfstat",
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes_multicore",
-      "command": "bash pausetimes_multicore %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+      "command": "bash pausetimes_multicore %{output} -- %{paramwrapper} chrt -r 1 %{command}"
     }
   ],
   "benchmarks": [

--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "orunchrt",
-      "command": "orun -o %{output} -- %{paramwrapper} chrt -r 1 %{command}"
+      "command": "orun -o %{output} -- chrt -r 1 %{paramwrapper} %{command}"
     },
     {
       "name": "perfstat",
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes_multicore",
-      "command": "bash pausetimes_multicore %{output} -- %{paramwrapper} chrt -r 1 %{command}"
+      "command": "bash pausetimes_multicore %{output} -- chrt -r 1 %{paramwrapper} %{command}"
     }
   ],
   "benchmarks": [

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes_multicore",
-      "command": "bash pausetimes_multicore %{output} %{paramwrapper} %{command}"
+      "command": "bash pausetimes_multicore %{output} -- chrt -r 1 %{paramwrapper} %{command}"
     }
   ],
 

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "orunchrt",
-      "command": "orun -o %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+      "command": "orun -o %{output} -- %{paramwrapper} chrt -r 1 %{command}"
     },
     {
       "name": "perfstat",
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes_multicore",
-      "command": "bash pausetimes_multicore %{output} -- chrt -r 1 %{paramwrapper} %{command}"
+      "command": "bash pausetimes_multicore %{output} -- %{paramwrapper} chrt -r 1 %{command}"
     }
   ],
 


### PR DESCRIPTION
The PR adds `chrt` to the `pausetimes_multicore` wrapper to make sure the taskset argument mentioned in the parawrapper is picked up.

The absence of `chrt` led to the benchmarks not pick up the taskset arguments resulting in slow nightly runs.

Thanks to @Engil he was able to pinpoint the problem to the cores not being used.