### PR TITLE
Add dune.2.9.0

### DIFF
--- a/dependencies/packages/dune/dune.2.9.0/opam
+++ b/dependencies/packages/dune/dune.2.9.0/opam
@@ -1,0 +1,53 @@
+x-commit-hash: "641a95d2254ca7c51c97f07f2eed85b7a95db954"
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free."""
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.9.0/dune-2.9.0.tbz"
+  checksum: [
+    "sha256=bb217cfb17e893a0b1eb002ac83c14f96adc9d0703cb51ff34ed3ef5a639a41e"
+    "sha512=fcd8bc3ea7e9a14e6787a3b0384a488e45fa51e164a175ad1b147bebb3fbcccfd8f321b9b6a7665ac3dafeb18a2a6f8626d182af3b1796691f6ed79c166a5f44"
+  ]
+}


### PR DESCRIPTION
After investigating the hanging of the `coq` build with Multicore OCaml, under some specific scenario, it turns out updating `dune`  to 2.9.0 fixes the issue.
This specific hang is still a bit of a mystery to me, but it seems like the failure to build `coq` with Multicore triggers a loop in a retry mechanism in `dune`'s fibers.

I also noticed that we still have a _system dune_ in place to work around past compatibility issues with `4.09.0` and Multicore not being able to build `dune` by itself.

It does seems the dune version used by the sandmark run is indeed the one installed in the switch. (and not the system dune)

I was wondering if there was a reason why we still have the system dune setup active in sandmark? I assume it is still useful for trunk (since dune may break against trunk), however Multicore+dune compatibility is not an issue anymore.

