### PR TITLE
Remove Domain.Sync.poll() from parallel benchmarks 

### DIFF
--- a/benchmarks/multicore-minilight/parallel/rayTracer.ml
+++ b/benchmarks/multicore-minilight/parallel/rayTracer.ml
@@ -85,7 +85,7 @@ object (__)
     * @return (Vector3f.vT) light value in radiance
     *)
    method radiance rayOrigin rayDirection ?lastHit random =
-			Domain.Sync.poll();
+
       (* intersect ray with scene *)
       match scene_m#intersection rayOrigin rayDirection lastHit with
 

--- a/benchmarks/multicore-minilight/parallel/scene.ml
+++ b/benchmarks/multicore-minilight/parallel/scene.ml
@@ -42,7 +42,6 @@ class obj inBuffer_i eyePosition_i =
 
    (* read triangles in sequence *)
    let triangles_c = let rec readTriangle ts i =
-         Domain.Sync.poll ();
          try
             if i = 0 then
                ts else readTriangle ((new Triangle.obj inBuffer_i) :: ts) (i-1)

--- a/benchmarks/multicore-minilight/parallel/spatialIndex.ml
+++ b/benchmarks/multicore-minilight/parallel/spatialIndex.ml
@@ -71,7 +71,6 @@ and maxItems_k  =  8
  * @return (SpatialIndex.node)
  *)
 let rec construct bound items level =
-	 Domain.Sync.poll ();
    (* if items overflow leaf and tree not too deep --
       make branch: make subcells, and recurse construction *)
    if (List.length items > maxItems_k) && (level < (maxLevels_k - 1)) then
@@ -159,7 +158,6 @@ let create eyePosition items =
  * @return (Triangle.var, Vector3f.vT) object|null hit, and hit position
  *)
 let rec intersection octree rayOrigin rayDirection ?(start = rayOrigin) lastHit =
-	 Domain.Sync.poll();
    match octree with
 
    (* is branch: step through subcells and recurse *)
@@ -174,7 +172,6 @@ let rec intersection octree rayOrigin rayDirection ?(start = rayOrigin) lastHit 
 
       (* define subcell walker *)
       let rec walk subCell cellPosition =
-         Domain.Sync.poll();
 
          (* intersect subcell *)
          match intersection subCells.(subCell) rayOrigin rayDirection

--- a/benchmarks/multicore-minilight/parallel/triangle.ml
+++ b/benchmarks/multicore-minilight/parallel/triangle.ml
@@ -44,7 +44,6 @@ class obj inBuffer_i =
       three vertexs, then reflectivity, then emitivity *)
    let vectors_c = 
        let rec readVectors vs i = 
-         Domain.Sync.poll();
          if i = 0 then vs else
          readVectors ((vRead inBuffer_i) :: vs) (i - 1) in readVectors [] 5 
    in

--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -12,7 +12,6 @@ let rec make d =
   else let d = d - 1 in Node(make d, make d)
 
 let rec check t =
-  Domain.Sync.poll ();
   match t with
   | Empty -> 0
   | Node(l, r) -> 1 + check l + check r

--- a/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
+++ b/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
@@ -19,7 +19,6 @@ let chromosome { chromosome=x; fitness=_ } = x
 let evaluate f x = { chromosome=x; fitness=(f x) }
 
 let fittest x y =
-  Domain.Sync.poll ();
   if x.fitness > y.fitness then x else y
 let pop_fittest pop = Array.fold_left fittest pop.(0) pop
 

--- a/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
+++ b/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
@@ -51,9 +51,9 @@ let f_w pool adj =
               adj.(i).(j) <- Value (a_ik + a_kj)
             | Value a_ij, Value a_kj when a_ik + a_kj < a_ij ->
               adj.(i).(j) <- Value (a_ik + a_kj)
-            | _, _ -> Domain.Sync.poll()
+            | _, _ -> ()
         done
-      | Infinity -> Domain.Sync.poll()
+      | Infinity -> ()
       );
   done
 

--- a/benchmarks/multicore-numerical/mandelbrot6_multicore.ml
+++ b/benchmarks/multicore-numerical/mandelbrot6_multicore.ml
@@ -35,7 +35,6 @@ let worker w h_lo h_hi =
       and zr = ref 0. and zi = ref 0. and trmti = ref 0. and n = ref 0 in
       begin try
   while true do
-    Domain.Sync.poll ();
     zi := 2. *. !zr *. !zi +. ci;
     zr := !trmti +. cr;
     let tr = !zr *. !zr and ti = !zi *. !zi in

--- a/benchmarks/multicore-numerical/matrix_multiplication_tiling_multicore.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication_tiling_multicore.ml
@@ -24,7 +24,6 @@ let matrix_multiply z x y s e =
       for i= 0 to (pred ts) do
         for j= 0 to (pred ts) do
           for k=0 to (pred ts) do
-            Domain.Sync.poll();
             z.(!bi+i).(!bj+j) <- z.(!bi+i).(!bj+j) + x.(!bi+i).(!bk+k) * y.(!bk+k).(!bj+j)
           done
         done

--- a/benchmarks/multicore-numerical/nbody_multicore.ml
+++ b/benchmarks/multicore-numerical/nbody_multicore.ml
@@ -26,7 +26,6 @@ let advance pool bodies dt =
       let b = bodies.(i) in
       let vx, vy, vz = ref b.vx, ref b.vy, ref b.vz in
       for j = 0 to Array.length bodies - 1 do
-        Domain.Sync.poll();
         let b' = bodies.(j) in
         if (i!=j) then begin
           let dx = b.x -. b'.x  and dy = b.y -. b'.y  and dz = b.z -. b'.z in
@@ -41,7 +40,6 @@ let advance pool bodies dt =
       b.vy <- !vy;
       b.vz <- !vz);
   for i = 0 to num_bodies - 1 do
-    Domain.Sync.poll();
     let b = bodies.(i) in
     b.x <- b.x +. dt *. b.vx;
     b.y <- b.y +. dt *. b.vy;
@@ -60,7 +58,6 @@ let energy pool bodies =
         let dx = b.x -. b'.x  and dy = b.y -. b'.y  and dz = b.z -. b'.z in
         let distance = sqrt(dx *. dx +. dy *. dy +. dz *. dz) in
         e := !e -. (b.mass *. b'.mass) /. distance;
-        Domain.Sync.poll ()
       done;
       !e)
 

--- a/benchmarks/multicore-numerical/quicksort_multicore.ml
+++ b/benchmarks/multicore-numerical/quicksort_multicore.ml
@@ -13,7 +13,6 @@ let partition arr low high =
   if (high-low > 0) then
     begin
       for j= low to high - 1 do
-        Domain.Sync.poll ();
         if arr.(j) <= x then
           begin
             i := !i+1;


### PR DESCRIPTION
Multicore OCaml programs no longer need Domain.Sync.poll () since safe points have been merged into Multicore OCaml: https://github.com/ocaml-multicore/ocaml-multicore/pull/573. The PR removes the calls to `poll` from the parallel benchmarks in Sandmark. 