### PR TITLE
Update benchmarks and domainslib to support ocaml 4.14.0+domains (ocaml 5.0)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,6 +49,33 @@ steps:
 
 ---
 kind: pipeline
+name: 4.14.0+domains+parallel
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: 4.14.0+domains+parallel
+  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
+  commands:
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
+  - pip3 install intervaltree
+  - sudo chown -R opam .
+  - eval $(opam env)
+  - opam update
+  - opam install dune.2.9.0
+  - export ITER=1
+  - export OPAM_DISABLE_SANDBOXING=true
+  - TAG='"run_in_ci"' make multicore_parallel_run_config_filtered.json
+  - TAG='"macro_bench"' make multicore_parallel_run_config_filtered_filtered.json
+  - make multicore_parallel_run_config_filtered_filtered_2domains.json
+  - BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.14.0+domains.bench
+  - ls _results
+  - cat _results/*
+
+---
+kind: pipeline
 name: test_notebooks
 
 platform:

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,31 +24,6 @@ steps:
 
 ---
 kind: pipeline
-name: 4.12.0+stock+serial
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: 4.12.0+stock
-  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
-  commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
-  - pip3 install intervaltree
-  - sudo chown -R opam .
-  - eval $(opam env)
-  - opam update
-  - opam install dune.2.9.0
-  - export ITER=1
-  - export OPAM_DISABLE_SANDBOXING=true
-  - TAG='"run_in_ci"' make run_config_filtered.json
-  - RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.12.0+stock.bench
-  - ls _results
-  - cat _results/*
-
----
-kind: pipeline
 name: 4.12.0+domains+serial
 
 platform:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 kind: pipeline
-name: 4.14.0+trunk+serial
+name: 5.00.0+trunk+serial
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,31 +24,6 @@ steps:
 
 ---
 kind: pipeline
-name: 4.12.0+domains+serial
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: 4.12.0+domains+serial
-  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
-  commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
-  - pip3 install intervaltree
-  - sudo chown -R opam .
-  - eval $(opam env)
-  - opam update
-  - opam install dune.2.9.0
-  - export ITER=1
-  - export OPAM_DISABLE_SANDBOXING=true
-  - TAG='"run_in_ci"' make run_config_filtered.json
-  - RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.12.0+domains.bench
-  - ls _results
-  - cat _results/*
-
----
-kind: pipeline
 name: 4.14.0+domains+serial
 
 platform:
@@ -69,33 +44,6 @@ steps:
   - export OPAM_DISABLE_SANDBOXING=true
   - TAG='"run_in_ci"' make run_config_filtered.json
   - RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.14.0+domains.bench
-  - ls _results
-  - cat _results/*
-
----
-kind: pipeline
-name: 4.12.0+domains+parallel
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: 4.12.0+domains+parallel
-  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
-  commands:
-  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip
-  - pip3 install intervaltree
-  - sudo chown -R opam .
-  - eval $(opam env)
-  - opam update
-  - opam install dune.2.9.0
-  - export ITER=1
-  - export OPAM_DISABLE_SANDBOXING=true
-  - TAG='"run_in_ci"' make multicore_parallel_run_config_filtered.json
-  - TAG='"macro_bench"' make multicore_parallel_run_config_filtered_filtered.json
-  - make multicore_parallel_run_config_filtered_filtered_2domains.json
-  - BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.12.0+domains.bench
   - ls _results
   - cat _results/*
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json
 		*multicore*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ;; \
 		*effects*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ;; \
 		*domains*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock ;; \
+		*5.00*) sed 's/(alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/; (alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/g' ./benchmarks/irmin/dune > ./benchmarks/irmin/dune ;; \
 		*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock coq fraplib ;; \
 	esac }; \
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,15 @@ WRAPPER = $(patsubst run_%,%,$(RUN_BENCH_TARGET))
 
 PACKAGES = \
 	cpdf conf-pkg-config conf-zlib bigstringaf decompress camlzip menhirLib \
-	menhir minilight base stdio dune-private-libs dune-configurator camlimages \
-	yojson lwt zarith integers uuidm react ocplib-endian nbcodec checkseum \
+	menhir minilight base dune-private-libs dune-configurator camlimages \
+	yojson lwt zarith uuidm react ocplib-endian nbcodec checkseum \
 	sexplib0 eventlog-tools cubicle conf-findutils logs \
 	mtime  repr 
 
 ifeq ($(findstring multibench,$(BUILD_BENCH_TARGET)),multibench)
 	PACKAGES += lockfree kcas domainslib ctypes.0.14.0+multicore
 else
-	PACKAGES += ctypes.0.14.0+stock frama-c  alt-ergo js_of_ocaml-compiler
+	PACKAGES += ctypes.0.14.0+stock frama-c  alt-ergo 
 endif
 
 DEPENDENCIES = libgmp-dev libdw-dev jq python3-pip pkg-config m4 # Ubuntu
@@ -110,11 +110,11 @@ ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json
 	opam install --switch=$* --keep-build-dir --yes rungen orun
 	@# case statement to select the correct variant for omp and ppxlib
 	@{ case "$*" in \
-		*multicore*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin  ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
-		*effects*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
-		*domains*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock  ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
-		*5.00*) sed 's/(alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/; (alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/g' ./benchmarks/irmin/dune > ./benchmarks/irmin/dune  index ;; \
-		*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock coq fraplib ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
+		*multicore*) opam install --switch=$* --keep-build-dir --yes stdio integers  ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin  ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
+		*effects*) opam install --switch=$* --keep-build-dir --yes stdio integers  ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
+		*domains*) opam install --switch=$* --keep-build-dir --yes stdio integers ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock  ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
+		*5.00*) sed 's/(alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/; (alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/g' ./benchmarks/irmin/dune > ./benchmarks/irmin/dune ;; \
+		*) opam install --switch=$* --keep-build-dir --yes stdio integers  ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock js_of_ocaml-compiler coq fraplib ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
 	esac }; \
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 	opam exec --switch $* -- opam list

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ PACKAGES = \
 	cpdf conf-pkg-config conf-zlib bigstringaf decompress camlzip menhirLib \
 	menhir minilight base stdio dune-private-libs dune-configurator camlimages \
 	yojson lwt zarith integers uuidm react ocplib-endian nbcodec checkseum \
-	sexplib0 eventlog-tools irmin cubicle conf-findutils index logs \
-	mtime ppx_deriving ppx_deriving_yojson ppx_irmin repr ppx_repr irmin-layers irmin-pack
+	sexplib0 eventlog-tools cubicle conf-findutils logs \
+	mtime  repr 
 
 ifeq ($(findstring multibench,$(BUILD_BENCH_TARGET)),multibench)
 	PACKAGES += lockfree kcas domainslib ctypes.0.14.0+multicore
@@ -110,11 +110,11 @@ ocaml-versions/%.bench: check_url depend log_sandmark_hash ocaml-versions/%.json
 	opam install --switch=$* --keep-build-dir --yes rungen orun
 	@# case statement to select the correct variant for omp and ppxlib
 	@{ case "$*" in \
-		*multicore*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ;; \
-		*effects*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ;; \
-		*domains*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock ;; \
-		*5.00*) sed 's/(alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/; (alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/g' ./benchmarks/irmin/dune > ./benchmarks/irmin/dune ;; \
-		*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock coq fraplib ;; \
+		*multicore*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin  ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
+		*effects*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.1.0+multicore ppxlib.0.22.0+multicore ppx_deriving ppx_deriving_yojson irmin ppx_irmin  ppx_repr irmin-layers irmin-pack index ;; \
+		*domains*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock  ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
+		*5.00*) sed 's/(alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/; (alias (name buildbench) (deps layers.exe irmin_mem_rw.exe))/g' ./benchmarks/irmin/dune > ./benchmarks/irmin/dune  index ;; \
+		*) opam install --switch=$* --keep-build-dir --yes ocaml-migrate-parsetree.2.2.0+stock ppxlib.0.22.0+stock coq fraplib ppx_deriving ppx_deriving_yojson irmin ppx_irmin ppx_repr irmin-layers irmin-pack index ;; \
 	esac }; \
 	opam install --switch=$* --best-effort --keep-build-dir --yes $(PACKAGES) || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 	opam exec --switch $* -- opam list
@@ -174,6 +174,7 @@ clean:
 	rm -rf _results
 	rm -rf *filtered.json
 	rm -rf *~
+	git restore ./benchmarks/irmin/dune
 
 list:
 	@echo $(ocamls)

--- a/benchmarks/decompress/test_decompress_multicore.ml
+++ b/benchmarks/decompress/test_decompress_multicore.ml
@@ -82,7 +82,7 @@ let work _i =
   ignore (Atomic.fetch_and_add iter_count 1)
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  T.parallel_for pool ~start:1 ~finish:iterations ~body:work;
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  T.parallel_for ~start:1 ~finish:iterations ~body:work pool;
   T.teardown_pool pool;
   assert ((Atomic.get iter_count) = iterations)

--- a/benchmarks/multicore-minilight/parallel/camera.ml
+++ b/benchmarks/multicore-minilight/parallel/camera.ml
@@ -78,7 +78,7 @@ object (__)
 
       (* do image sampling pixel loop *)
       let () =
-        T.parallel_for pool ~start:0 ~finish:(image#height - 1)
+        T.parallel_for ~start:0 ~finish:(image#height - 1)
         ~body:(fun y -> for x = image#width - 1 downto 0 do
 
             let random = Domain.DLS.get k in
@@ -104,7 +104,7 @@ object (__)
             (* add radiance to pixel *)
             image#addToPixel x y radiance
 
-         done )
+         done ) pool
        in
 
       image

--- a/benchmarks/multicore-minilight/parallel/minilight_multicore.ml
+++ b/benchmarks/multicore-minilight/parallel/minilight_multicore.ml
@@ -116,7 +116,7 @@ try
 
       (* create top-level rendering objects with model file, in this order
          (image is mutable) *)
-      let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+      let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
       let image  = new Image.obj  modelFile in
       let camera = new Camera.obj modelFile pool in
       let scene  = new Scene.obj  modelFile camera#eyePoint in

--- a/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
+++ b/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
@@ -14,8 +14,8 @@ module SquareMatrix = struct
     fa
   let parallel_create pool f : float array =
     let fa = Array.create_float (mat_size * mat_size) in
-    T.parallel_for pool ~start:0 ~finish:( mat_size * mat_size - 1)
-      ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size));
+    T.parallel_for ~start:0 ~finish:( mat_size * mat_size - 1)
+      ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size)) pool;
     fa
 
   let get (m : float array) r c = m.(r * mat_size + c)
@@ -54,7 +54,7 @@ let lup pool (a0 : float array) =
   a
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let a = parallel_create pool
     (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
   let lu = lup pool a in

--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -2,7 +2,7 @@ module T = Domainslib.Task
 
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let max_depth = try int_of_string Sys.argv.(2) with _ -> 10
-let pool = T.setup_pool ~num_additional_domains:(num_domains - 1)
+let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) ()
 
 type 'a tree = Empty | Node of 'a tree * 'a tree
 

--- a/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
+++ b/benchmarks/multicore-numerical/evolutionary_algorithm_multicore.ml
@@ -69,8 +69,8 @@ let n = try int_of_string Sys.argv.(2) with _ -> 1000
 let multicore_init pool num_domains x0 n f =
   let a = Array.make n x0 in
   T.parallel_for
-    pool ~start:0 ~finish:(n-1)
-    ~body:(fun i -> a.(i) <- f ());
+    ~start:0 ~finish:(n-1)
+    ~body:(fun i -> a.(i) <- f ()) pool;
   a
 
 let evolutionary_algorithm
@@ -85,7 +85,7 @@ let evolutionary_algorithm
 
   =
 
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let adam = random_individual n fitness in
   let init_pop = multicore_init pool num_domains adam in
   let pop0 = init_pop lambda (fun _ -> random_individual n fitness) in

--- a/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
+++ b/benchmarks/multicore-numerical/floyd_warshall_multicore.ml
@@ -60,7 +60,7 @@ let f_w pool adj =
 let ()=
   Random.init 512;
   let adj = make_adj n in
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   (*
   let adj = [|
     [| Value 0; Value 8; Infinity; Value 1 |];

--- a/benchmarks/multicore-numerical/game_of_life_multicore.ml
+++ b/benchmarks/multicore-numerical/game_of_life_multicore.ml
@@ -50,11 +50,11 @@ let print g =
 let next pool =
   let g = !rg in
   let new_g = !rg' in
-  T.parallel_for pool ~start:0 ~finish:(board_size - 1)
+  T.parallel_for ~start:0 ~finish:(board_size - 1)
     ~body:(fun x ->
       for y = 0 to board_size - 1 do
         new_g.(x).(y) <- next_cell g x y
-      done);
+      done) pool;
   rg := new_g;
   rg' := g
 
@@ -65,7 +65,7 @@ let rec repeat pool n =
   | _-> next pool; repeat pool (n-1)
 
 let ()=
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   (* print !rg; *)
   repeat pool n_times;
   (* print !rg; *)

--- a/benchmarks/multicore-numerical/mandelbrot6_multicore.ml
+++ b/benchmarks/multicore-numerical/mandelbrot6_multicore.ml
@@ -65,10 +65,10 @@ let worker w h_lo h_hi =
   buf
 
 let _ =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   Printf.printf "P4\n%i %i\n%!" w w;
   let out = Array.init w (fun _ -> Bytes.create 0) in
   let work i = out.(i) <- worker w i (i+1) in
-  T.parallel_for pool ~start:0 ~finish:(w-1) ~body:work;
+  T.parallel_for ~start:0 ~finish:(w-1) ~body:work pool;
   Array.iter (fun o -> Printf.printf "%a%!" output_bytes o) out;
   T.teardown_pool pool

--- a/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
+++ b/benchmarks/multicore-numerical/matrix_multiplication_multicore.ml
@@ -8,14 +8,14 @@ let matrix_multiply pool res x y =
   let j_n = Array.length y.(0) in
   let k_n = Array.length y in
 
-  T.parallel_for pool ~start:0 ~finish:(i_n - 1) ~body:(fun i ->
+  T.parallel_for ~start:0 ~finish:(i_n - 1) ~body:(fun i ->
     for j = 0 to j_n -1 do
       let w = ref 0 in
       for k = 0 to k_n - 1 do
         w := !w + x.(i).(k) * y.(k).(j);
       done;
       res.(i).(j) <- !w
-    done)
+    done) pool
 
 let print_matrix m =
   for i = 0 to pred (Array.length m) do
@@ -26,7 +26,7 @@ let print_matrix m =
   done
 
 let _ =
-    let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+    let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
 
     let m1 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in
     let m2 = Array.init size (fun _ -> Array.init size (fun _ -> Random.int 100)) in

--- a/benchmarks/multicore-numerical/mergesort_multicore.ml
+++ b/benchmarks/multicore-numerical/mergesort_multicore.ml
@@ -3,7 +3,7 @@ module T = Domainslib.Task
 let num_domains = try int_of_string @@ Sys.argv.(1) with _ -> 1
 let n = try int_of_string @@ Sys.argv.(2) with _ -> 1024
 let min = 128
-let pool = T.setup_pool ~num_additional_domains:(num_domains - 1)
+let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) ()
 
 let _ = Random.init 42
 let a = Array.init n (fun _ -> Random.int n)

--- a/benchmarks/multicore-numerical/nbody_multicore.ml
+++ b/benchmarks/multicore-numerical/nbody_multicore.ml
@@ -84,7 +84,7 @@ let bodies =
       mass=(Random.float 10.) *. solar_mass; })
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   offset_momentum bodies;
   Printf.printf "%.9f\n" (energy pool bodies);
   for _i = 1 to n do advance pool bodies 0.01 done;

--- a/benchmarks/multicore-numerical/quicksort_multicore.ml
+++ b/benchmarks/multicore-numerical/quicksort_multicore.ml
@@ -39,7 +39,7 @@ let rec quicksort arr low high d pool =
   end
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let arr = Array.init n (fun _ -> Random.int n) in
   quicksort arr 0 (Array.length arr - 1) num_domains pool;
   (* for i = 0 to  Array.length arr - 1 do

--- a/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
+++ b/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
@@ -15,26 +15,26 @@ let eval_A i j = 1. /. float((i+j)*(i+j+1)/2+i+1)
 
 let eval_A_times_u pool u v =
   let n = Array.length v - 1 in
-  T.parallel_for pool ~start:0 ~finish:n
+  T.parallel_for ~start:0 ~finish:n
     ~body:(fun i ->
       let vi = ref 0. in
       for j = 0 to n do vi := !vi +. eval_A i j *. u.(j) done;
-      v.(i) <- !vi)
+      v.(i) <- !vi) pool 
 
 let eval_At_times_u pool u v =
   let n = Array.length v -1 in
-  T.parallel_for pool ~start:0 ~finish:n
+  T.parallel_for ~start:0 ~finish:n
     ~body:(fun i ->
     let vi = ref 0. in
     for j = 0 to n do vi := !vi +. eval_A j i *. u.(j) done;
-    v.(i) <- !vi)
+    v.(i) <- !vi) pool 
 
 let eval_AtA_times_u pool u v =
   let w = Array.make (Array.length u) 0.0 in
   eval_A_times_u pool u w; eval_At_times_u pool w v
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let u = Array.make n 1.0  and  v = Array.make n 0.0 in
   for _i = 0 to 9 do
     eval_AtA_times_u pool u v; eval_AtA_times_u pool v u

--- a/benchmarks/multicore-structures/test_spsc_queue_pingpong_parallel.ml
+++ b/benchmarks/multicore-structures/test_spsc_queue_pingpong_parallel.ml
@@ -12,11 +12,11 @@ let first_queue = !last_queue
 let rec spinning_enqueue q m =
     match Spsc_queue.enqueue q m with
     | true -> ()
-    | false -> Domain.Sync.cpu_relax(); spinning_enqueue q m
+    | false -> Domain.cpu_relax(); spinning_enqueue q m
 
 let rec ping_pong_messages n in_queue out_queue =
     match Spsc_queue.dequeue in_queue with
-    | None -> Domain.Sync.cpu_relax(); ping_pong_messages n in_queue out_queue
+    | None -> Domain.cpu_relax(); ping_pong_messages n in_queue out_queue
     | Some(m) -> 
     begin
         spinning_enqueue out_queue m;

--- a/dependencies/packages/domainslib/domainslib.0.3.2/opam
+++ b/dependencies/packages/domainslib/domainslib.0.3.2/opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
   "dune" {>= "1.8"}
-  "base-domains"
   "mirage-clock-unix" {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/dependencies/packages/domainslib/domainslib.0.3.2/opam
+++ b/dependencies/packages/domainslib/domainslib.0.3.2/opam
@@ -2,21 +2,20 @@ opam-version: "2.0"
 maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
 authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
 homepage: "https://github.com/ocaml-multicore/domainslib"
-doc: "https://kayceesrk.github.io/domainslib/doc"
+doc: "https://ocaml-multicore.github.io/domainslib/"
 synopsis: "Parallel Structures over Domains for Multicore OCaml"
 license: "ISC"
 dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
-tags: []
+tags: ["org:ocamllabs"]
 depends: [
-  "ocamlfind" {build}
-  "dune" {build}
+  "dune" {>= "1.8"}
+  "base-domains"
+  "mirage-clock-unix" {with-test}
 ]
-depopts: []
-build: [
-  "dune" "build" "-p" name
-]
+build: ["dune" "build" "-p" name "-j" jobs]
 url {
-  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.0.tar.gz"
-  checksum: "md5=19ac2e92298b82a406bcb231a00bb3a4"
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.2.tar.gz"
+  checksum: "md5=b4c1ed2ca16b82c40de9a64989094639"
 }
+

--- a/ocaml-versions/4.14.0+trunk.json
+++ b/ocaml-versions/4.14.0+trunk.json
@@ -1,3 +1,0 @@
-{
-  "url" : "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
-}

--- a/ocaml-versions/5.00.0+trunk.json
+++ b/ocaml-versions/5.00.0+trunk.json
@@ -1,0 +1,2 @@
+{ "url" : "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
+}

--- a/run_config.json
+++ b/run_config.json
@@ -1482,8 +1482,7 @@
       "name": "irmin_mem_rw",
       "tags": [
         "1s_10s",
-        "macro_bench",
-        "run_in_ci"
+        "macro_bench"
       ],
       "runs": [
         {


### PR DESCRIPTION
This PR is the first step in adding ocaml 5.0 support for the benchmarks in sandmark.

The PR adds domainslib.0.3.2 and updates the benchmarks supporting the updated api for domainslib