### PR TITLE
Re-add 5.00.0+trunk with CI failure:ignore option

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,6 +51,61 @@ steps:
   - ls _results
   - cat _results/*
 
+kind: pipeline
+name: 5.00.0+trunk+serial
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: 5.00.0+trunk+serial
+  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
+  failure: ignore
+  commands:
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
+  - pip3 install intervaltree
+  - sudo chown -R opam .
+  - eval $(opam env)
+  - opam update
+  - opam install dune.2.9.0
+  - eval $(opam env)
+  - export ITER=1
+  - export OPAM_DISABLE_SANDBOXING=true
+  - TAG='"run_in_ci"' make run_config_filtered.json
+  - USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.00.0+trunk.bench
+  - ls _results
+  - cat _results/*
+
+---
+kind: pipeline
+name: 5.00.0+trunk+parallel
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: 5.00.0+trunk+parallel
+  image: ocaml/opam:ubuntu-20.04-ocaml-4.12
+  failure: ignore
+  commands:
+  - sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
+  - pip3 install intervaltree
+  - sudo chown -R opam .
+  - eval $(opam env)
+  - opam update
+  - opam install dune.2.9.0
+  - eval $(opam env)
+  - export ITER=1
+  - export OPAM_DISABLE_SANDBOXING=true
+  - TAG='"run_in_ci"' make multicore_parallel_run_config_filtered.json
+  - TAG='"macro_bench"' make multicore_parallel_run_config_filtered_filtered.json
+  - make multicore_parallel_run_config_filtered_filtered_2domains.json
+  - USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.00.0+trunk.bench
+  - ls _results
+  - cat _results/*
+
 ---
 kind: pipeline
 name: test_notebooks

--- a/ocaml-versions/5.00.0+trunk.json
+++ b/ocaml-versions/5.00.0+trunk.json
@@ -1,14 +1,16 @@
 {
   "url" : "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
   "package_overrides": [
-    "camlpdf.2.3",
-    "cpdf.2.3",
-    "fmt.0.9.0"
+    "fmt.0.9.0",
+    "ocamlfind.1.9.3"
   ],
   "package_remove": [
+    "camlpdf",
+    "cpdf",
     "coq",
     "coq-core",
     "coq-stdlib",
+    "ctypes",
     "fraplib",
     "index",
     "integers",


### PR DESCRIPTION
Adding `5.00+trunk` with the Drone CI `failure:ignore` option so that we will know if trunk fails to build for a PR, but it should not prevent a PR in getting merged if `5.00+stable` builds fine.