### PR TITLE
Updated run_all scripts and 5.00.0+stable to February 3, 2022 commit

### DIFF
--- a/ocaml-versions/5.00.0+stable.json
+++ b/ocaml-versions/5.00.0+stable.json
@@ -1,5 +1,5 @@
 {
-  "url" : "https://github.com/ocaml/ocaml/archive/ad8e6eb60285e69c71d09942d68b28abf51cbe93.zip",
+  "url" : "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
   "package_overrides": [
     "fmt.0.9.0",
     "ocamlfind.1.9.3"

--- a/run_all_parallel.sh
+++ b/run_all_parallel.sh
@@ -8,7 +8,8 @@
 
 TAG='"macro_bench"' make multicore_parallel_run_config_filtered.json
 
-RUN_BENCH_TARGET=run_orunchrt \
-	BUILD_BENCH_TARGET=multibench_parallel \
-	RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
-	make ocaml-versions/4.14.0+domains.bench
+USE_SYS_DUNE_HACK=1 \
+                 RUN_BENCH_TARGET=run_orunchrt \
+                 BUILD_BENCH_TARGET=multibench_parallel \
+                 RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \
+                 make ocaml-versions/5.00.0+stable.bench

--- a/run_all_serial.sh
+++ b/run_all_serial.sh
@@ -2,5 +2,4 @@
 
 TAG='"macro_bench"' make run_config_filtered.json
 
-RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.00.0+trunk.bench
-RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.14.0+domains.bench
+USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.00.0+stable.bench


### PR DESCRIPTION
* Updated run_all scripts to use SYS_DUNE_HACK and 5.00.0+stable variant.
* Changed 5.00.0+stable to February 3, 2022 `ocaml/ocaml` commit.