### PR TITLE
Add Custom Variant Support feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,12 +267,15 @@ define check_dependency
 endef
 
 check_url:
-	@{ for f in `find ocaml-versions/*.json`; do    	\
-		URL=`jq -r '.url' $$f`;                   	\
-		if [ -z "$$URL" ] ; then                  	\
-			echo "No URL (mandatory) for $$f";   	\
-		fi;                                       	\
-	    done;                                        	\
+	@{ for f in `find ocaml-versions/*.json`; do    		\
+                if [ "$$f" == "ocaml-versions/custom.json" ]; then	\
+                        continue;                               	\
+                fi;                                           		\
+		URL=`jq -r '.url' $$f`;                  		\
+		if [ -z "$$URL" ] ; then                  		\
+			echo "No URL (mandatory) for $$f";   		\
+		fi;                                       		\
+	    done;                                        		\
 	};
 
 depend:

--- a/ocaml-versions/custom.json
+++ b/ocaml-versions/custom.json
@@ -1,0 +1,23 @@
+[
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "run_in_ci",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+kc+pr23423",
+    "expiry": "2022-02-15"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "run_in_ci",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+kc+pr23423",
+    "expiry": "2022-02-15"
+  },
+  {
+    "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/eventring-pr.zip",
+    "tag": "run_in_ci",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+kc+pr23423",
+    "expiry": "2022-02-15"
+  }
+]

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Variables
+CUSTOM_FILE="ocaml-versions/custom.json"
+HOSTNAME=`hostname`
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR:-/tmp}
+
+# Number of Custom variants
+COUNT=`jq '. | length' "${CUSTOM_FILE}"` 
+
+# Functions
+check_sequential_parallel () {
+    if [[ $1 == *"multicore"* ]]; then
+        echo "parallel"
+    else
+        echo "sequential"
+    fi
+}
+
+check_not_expired () {
+    EXPIRY_DATE=$(date -d $1 +%s)
+    TODAY=`date +%Y-%m-%d`
+    CURRENT_DATE=$(date -d "${TODAY}" +%s)
+    if [[ "${CURRENT_DATE}" -le "${EXPIRY_DATE}" ]]; then
+        return 0
+    else                                                                                                                                                                                                                  return 1
+    fi
+}         
+
+find_commit () {
+    URL=$1
+    if [[ ${URL} == *"trunk"* ]]; then
+        COMMIT=`git ls-remote https://github.com/ocaml/ocaml.git refs/heads/trunk | awk -F' ' '{print $1}'`
+    elif [[ ${URL} == *"refs/heads"* ]]; then
+        GIT_SOURCE=`echo ${URL} | awk -F'/archive/' '{print $1}'`
+        REFS_PATH=`echo ${URL} | awk -F'/archive/' '{print $2}' | awk -F'.' '{print $1}'`
+        COMMIT=`git ls-remote ${GIT_SOURCE} ${REFS_PATH} | awk -F' ' '{print $1}'`
+    elif [[ ${URL} == *"archive"* ]]; then
+        COMMIT=`echo ${URL##*/} | awk -F'.' '{print $1}'`
+    else
+        echo "Error: Unable to find commit for ${URL}"
+        COMMIT=""
+    fi
+    echo "${COMMIT}" 
+}
+
+# Iterate through each variant
+i=0
+while [ $i -lt ${COUNT} ]; do
+    # Start new build
+    make clean
+
+    # Obtain configuration options
+    CONFIG_URL=`jq -r '.['$i'].url' "${CUSTOM_FILE}"`
+    CONFIG_TAG=`jq -r '.['$i'].tag' "${CUSTOM_FILE}"`
+    CONFIG_RUN_JSON=`jq -r '.['$i'].config_json' "${CUSTOM_FILE}"`
+    CONFIG_OPTIONS=`jq -r '.['$i'].configure // empty' "${CUSTOM_FILE}"`
+    CONFIG_RUN_PARAMS=`jq -r '.['$i'].runparams // empty' "${CUSTOM_FILE}"`
+    CONFIG_ENVIRONMENT=`jq -r '.['$i'].environment // empty' "${CUSTOM_FILE}"`
+    CONFIG_EXPIRY=`jq -r '.['$i'].expiry // empty' "${CUSTOM_FILE}"`
+    TAG_STRING=`echo \"${CONFIG_TAG}\"`
+
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)    
+    SEQPAR=$(check_sequential_parallel ${CONFIG_RUN_JSON})
+    COMMIT=$(find_commit ${CONFIG_URL})
+    NOT_EXPIRED=$(check_not_expired ${CONFIG_EXPIRY})
+    
+    echo "INFO: ${TIMESTAMP} Running benchmarks for URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT}"
+    
+    if [[ ! -z "${COMMIT}" ]] && check_not_expired ${CONFIG_EXPIRY} ; then
+        # Prepare run JSON
+        TAG=`echo "${TAG_STRING}"` make `echo ${CONFIG_RUN_JSON}`
+
+        # Build and execute benchmarks
+        USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
+                         RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
+                         ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
+                         OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
+                         OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
+                         make ocaml-versions/5.00.0+stable.bench
+
+        # Copy results
+        RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${SEQPAR}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"
+        mkdir -p "${RESULTS_DIR}"
+        cp _results/* "${RESULTS_DIR}"
+    else
+        echo "WARNING: ${TIMESTAMP}: Not running URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT} and EXPIRY=${CONFIG_EXPIRY}"
+    fi
+    
+    # Next custom variant
+    i=$((i+1))
+done


### PR DESCRIPTION
The PR is for the Custom Variant Support feature request at https://github.com/ocaml-bench/sandmark/issues/274.
* The following parameters (`url`, `tag`, `config_json`, `name`, `expiry`, `environment`, `configure`, `runparams`) are used in an `ocaml-versions/custom.json` file.
* `SANDMARK_NIGHTLY_DIR` can be passed as an environment variable to the `run_all_custom.sh` script.
* The following three URLs are supported:
1. `ocaml/ocaml`
    https://github.com/ocaml/ocaml/archive/trunk.tar.gz
2. A specific commit
    https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip
3. A developer branch
    https://github.com/sadiqj/ocaml/archive/refs/heads/eventring-pr.zip
* You can test the same using:
```
$ bash run_all_custom.sh
```