### PR TITLE
Use specific name in .orun.summary.bench output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ SANDMARK_REMOVE_PACKAGES ?= ""
 # Default list of packages to override
 SANDMARK_OVERRIDE_PACKAGES ?= ""
 
+# Override orun with custom name
+SANDMARK_CUSTOM_NAME ?= ""
+
 # Flag to select whether to use sys_dune_hack
 USE_SYS_DUNE_HACK ?= 0
 
@@ -229,8 +232,8 @@ ocaml-versions/%.bench: check_url depend override_packages/% log_sandmark_hash o
 			fi; \
 			done; \
 			header_entry=`jo -p $${s} | jq -c`; \
-			echo "$${header_entry}" > _results/$(CONFIG_SWITCH_NAME)_$$i.$(WRAPPER).summary.bench; \
-			find _build/$(CONFIG_SWITCH_NAME)_$$i -name '*.$(WRAPPER).bench' | xargs cat >> _results/$(CONFIG_SWITCH_NAME)_$$i.$(WRAPPER).summary.bench;		\
+			echo "$${header_entry}" > _results/$(SANDMARK_CUSTOM_NAME)_$$i.$(WRAPPER).summary.bench; \
+			find _build/$(CONFIG_SWITCH_NAME)_$$i -name '*.$(WRAPPER).bench' | xargs cat >> _results/$(SANDMARK_CUSTOM_NAME)_$$i.$(WRAPPER).summary.bench;		\
 	        done; 															\
 		exit $$ex; 														\
 	   else 															\

--- a/ocaml-versions/custom.json
+++ b/ocaml-versions/custom.json
@@ -1,23 +1,37 @@
 [
   {
     "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
-    "tag": "run_in_ci",
+    "tag": "macro_bench",
     "config_json": "run_config_filtered.json",
-    "name": "5.00+trunk+kc+pr23423",
-    "expiry": "2022-02-15"
+    "name": "5.00+trunk+sequential",
+    "expiry": "2100-01-01"
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
-    "tag": "run_in_ci",
+    "tag": "macro_bench",
     "config_json": "run_config_filtered.json",
-    "name": "5.00+trunk+kc+pr23423",
-    "expiry": "2022-02-15"
+    "name": "5.00+stable+sequential",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_run_config_filtered.json",
+    "name": "5.00+trunk+parallel",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_run_config_filtered.json",
+    "name": "5.00+stable+parallel",
+    "expiry": "2100-01-01"
   },
   {
     "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/eventring-pr.zip",
     "tag": "run_in_ci",
     "config_json": "run_config_filtered.json",
-    "name": "5.00+trunk+kc+pr23423",
-    "expiry": "2022-02-15"
+    "name": "5.00+trunk+sadiqj+pr10964",
+    "expiry": "2022-02-25"
   }
 ]

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -54,6 +54,7 @@ while [ $i -lt ${COUNT} ]; do
     CONFIG_URL=`jq -r '.['$i'].url' "${CUSTOM_FILE}"`
     CONFIG_TAG=`jq -r '.['$i'].tag' "${CUSTOM_FILE}"`
     CONFIG_RUN_JSON=`jq -r '.['$i'].config_json' "${CUSTOM_FILE}"`
+    CONFIG_NAME=`jq -r '.['$i'].name' "${CUSTOM_FILE}"`
     CONFIG_OPTIONS=`jq -r '.['$i'].configure // empty' "${CUSTOM_FILE}"`
     CONFIG_RUN_PARAMS=`jq -r '.['$i'].runparams // empty' "${CUSTOM_FILE}"`
     CONFIG_ENVIRONMENT=`jq -r '.['$i'].environment // empty' "${CUSTOM_FILE}"`
@@ -72,12 +73,25 @@ while [ $i -lt ${COUNT} ]; do
         TAG=`echo "${TAG_STRING}"` make `echo ${CONFIG_RUN_JSON}`
 
         # Build and execute benchmarks
-        USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
-                         RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
-                         ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
-                         OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
-                         OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
-                         make ocaml-versions/5.00.0+stable.bench
+        if [[ ${SEQPAR} == "sequential" ]]; then
+            USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
+                             RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
+                             ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
+                             OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
+                             OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
+                             SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
+                             make ocaml-versions/5.00.0+stable.bench
+        else
+            USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
+                             RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
+                             ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
+                             OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
+                             OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
+                             SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
+                             RUN_BENCH_TARGET=run_orunchrt \
+                             BUILD_BENCH_TARGET=multibench_parallel \
+                             make ocaml-versions/5.00.0+stable.bench
+        fi
 
         # Copy results
         RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${SEQPAR}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"


### PR DESCRIPTION
* The `name` in `custom.json` is now used in the `orun.summary.bench` file for use with sandmark-nightly.
* Updated `custom.json` to build for 5.00.0+trunk and 5.00+0+stable targets for both sequential and parallel benchmarks.
* A developer branch is added to demonstrate its use as an example.