### PR TITLE
Use separate custom variant JSON files per server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ log_sandmark_hash:
 blah:
 	@echo ${PACKAGES}
 
-ocaml-versions/%.bench: check_url depend override_packages/% log_sandmark_hash ocaml-versions/%.json .FORCE
+ocaml-versions/%.bench: depend override_packages/% log_sandmark_hash ocaml-versions/%.json .FORCE
 	$(eval CONFIG_SWITCH_NAME = $*)
 	$(eval CONFIG_OPTIONS      = $(shell jq -r '.configure // empty' ocaml-versions/$*.json))
 	$(eval CONFIG_RUN_PARAMS   = $(shell jq -r '.runparams // empty' ocaml-versions/$*.json))

--- a/ocaml-versions/custom_navajo.json
+++ b/ocaml-versions/custom_navajo.json
@@ -1,0 +1,37 @@
+[
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "macro_bench",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+sequential",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "macro_bench",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+stable+sequential",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_navajo_run_config_filtered.json",
+    "name": "5.00+trunk+parallel",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_navajo_run_config_filtered.json",
+    "name": "5.00+stable+parallel",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/eventring-pr.zip",
+    "tag": "run_in_ci",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+sadiqj+pr10964",
+    "expiry": "2022-02-25"
+  }
+]

--- a/ocaml-versions/custom_turing.json
+++ b/ocaml-versions/custom_turing.json
@@ -1,0 +1,37 @@
+[
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "macro_bench",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+sequential",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "macro_bench",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+stable+sequential",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_run_config_filtered.json",
+    "name": "5.00+trunk+parallel",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
+    "tag": "macro_bench",
+    "config_json": "multicore_parallel_run_config_filtered.json",
+    "name": "5.00+stable+parallel",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/eventring-pr.zip",
+    "tag": "run_in_ci",
+    "config_json": "run_config_filtered.json",
+    "name": "5.00+trunk+sadiqj+pr10964",
+    "expiry": "2022-02-25"
+  }
+]

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Variables
-CUSTOM_FILE="ocaml-versions/custom.json"
-HOSTNAME=`hostname`
+# Environment variables
+CUSTOM_FILE=${CUSTOM_FILE:-"ocaml-versions/custom.json"}
 SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR:-/tmp}
+
+# Host
+HOSTNAME=`hostname`
 
 # Number of Custom variants
 COUNT=`jq '. | length' "${CUSTOM_FILE}"` 


### PR DESCRIPTION
* Use separate custom variant JSON files to build on server machines by using a `CUSTOM_FILE` environment variable.
* The `check_url` is temporarily disabled, and a follow-up issue to update the same has been added at https://github.com/ocaml-bench/sandmark/issues/286.