### PR TITLE
Use CPU 5 in run_config.json for consistency

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -25,7 +25,8 @@ check_not_expired () {
     CURRENT_DATE=$(date -d "${TODAY}" +%s)
     if [[ "${CURRENT_DATE}" -le "${EXPIRY_DATE}" ]]; then
         return 0
-    else                                                                                                                                                                                                                  return 1
+    else
+        return 1
     fi
 }         
 

--- a/run_config.json
+++ b/run_config.json
@@ -2,7 +2,7 @@
   "wrappers": [
     {
       "name": "orun",
-      "command": "orun -o %{output} -- taskset --cpu-list 1 %{command}"
+      "command": "orun -o %{output} -- taskset --cpu-list 5 %{command}"
     },
     {
       "name": "perfstat",


### PR DESCRIPTION
* Use `--cpu-list` 5 for consistency.