### PR TITLE
Custom script log output to results directory

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -72,6 +72,10 @@ while [ $i -lt ${COUNT} ]; do
     echo "INFO: ${TIMESTAMP} Running benchmarks for URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT}"
     
     if [[ ! -z "${COMMIT}" ]] && check_not_expired ${CONFIG_EXPIRY} ; then
+        # Create results directory
+        RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${SEQPAR}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"
+        mkdir -p "${RESULTS_DIR}"
+
         # Prepare run JSON
         TAG=`echo "${TAG_STRING}"` make `echo ${CONFIG_RUN_JSON}`
 
@@ -83,7 +87,7 @@ while [ $i -lt ${COUNT} ]; do
                              OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
                              OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
                              SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
-                             make ocaml-versions/5.00.0+stable.bench
+                             make ocaml-versions/5.00.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
         else
             USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
                              RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
@@ -93,12 +97,10 @@ while [ $i -lt ${COUNT} ]; do
                              SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
                              RUN_BENCH_TARGET=run_orunchrt \
                              BUILD_BENCH_TARGET=multibench_parallel \
-                             make ocaml-versions/5.00.0+stable.bench
+                             make ocaml-versions/5.00.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
         fi
 
         # Copy results
-        RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${SEQPAR}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"
-        mkdir -p "${RESULTS_DIR}"
         cp _results/* "${RESULTS_DIR}"
     else
         echo "WARNING: ${TIMESTAMP}: Not running URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT} and EXPIRY=${CONFIG_EXPIRY}"


### PR DESCRIPTION
* Store the log of the build and execution of the benchmark results in the target ${RESULTS_DIR} for the Custom Variant run.
* The co-location of the log and the .bench results are useful for quick reference.