### PR TITLE
Clean OCaml dependencies/packages fully after a build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,8 @@ clean:
 	rm -rf _results
 	rm -rf *filtered.json
 	rm -rf *~
+	git checkout -- dependencies
+	git clean -fd dependencies/packages/ocaml-base-compiler dependencies/packages/ocaml
 	git restore ./benchmarks/irmin/dune
 	git restore ./benchmarks/cpdf/dune
 


### PR DESCRIPTION
The OCaml dependencies get overwritten during a build and execution, and need to be cleaned correctly.