### PR TITLE
Use a single `Task.run` in parallel benchmarks

### DIFF
--- a/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
+++ b/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
@@ -14,9 +14,8 @@ module SquareMatrix = struct
     fa
   let parallel_create pool f : float array =
     let fa = Array.create_float (mat_size * mat_size) in
-    T.run pool (fun _ ->
       T.parallel_for ~start:0 ~finish:( mat_size * mat_size - 1)
-        ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size)) pool);
+        ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size)) pool;
     fa
 
   let get (m : float array) r c = m.(r * mat_size + c)
@@ -42,25 +41,25 @@ end
 open SquareMatrix
 
 let lup pool (a0 : float array) =
-  let a = T.run pool (fun _ -> parallel_copy pool a0) in
+  let a = parallel_copy pool a0 in
   for k = 0 to (mat_size - 2) do
-    T.run pool (fun _ ->
       T.parallel_for pool ~start:(k + 1) ~finish:(mat_size  -1)
         ~body:(fun row ->
           let factor = get a row k /. get a k k in
           for col = k + 1 to mat_size-1 do
             set a row col (get a row col -. factor *. (get a k col))
           done;
-          set a row k factor )
-      );
+          set a row k factor);
   done;
   a
 
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  T.run pool (fun _ ->
   let a = parallel_create pool
     (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
   let lu = lup pool a in
   let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
   let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in
+  ());
   T.teardown_pool pool

--- a/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
+++ b/benchmarks/multicore-numerical/LU_decomposition_multicore.ml
@@ -30,7 +30,7 @@ module SquareMatrix = struct
     let b = Array.create_float n in
     let rec aux acc num_domains i =
       if (i = num_domains) then
-        (List.iter (fun e -> T.run pool (fun _ -> T.await pool e) acc))
+        (List.iter (fun e -> T.await pool e) acc)
       else begin
         aux ((T.async pool (fun _ -> copy_part a b i))::acc) num_domains (i+1)
       end
@@ -42,7 +42,7 @@ end
 open SquareMatrix
 
 let lup pool (a0 : float array) =
-  let a = parallel_copy pool a0 in
+  let a = T.run pool (fun _ -> parallel_copy pool a0) in
   for k = 0 to (mat_size - 2) do
     T.run pool (fun _ ->
       T.parallel_for pool ~start:(k + 1) ~finish:(mat_size  -1)

--- a/benchmarks/multicore-numerical/binarytrees5_multicore.ml
+++ b/benchmarks/multicore-numerical/binarytrees5_multicore.ml
@@ -2,7 +2,6 @@ module T = Domainslib.Task
 
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let max_depth = try int_of_string Sys.argv.(2) with _ -> 10
-let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) ()
 
 type 'a tree = Empty | Node of 'a tree * 'a tree
 
@@ -39,21 +38,21 @@ let calculate d st en ind =
   (* Printf.printf "ind = %d\n" ind; *)
   values.(ind) <- !c
 
-let loop_depths d =
+let loop_depths d pool =
   for i = 0 to  ((max_depth - d) / 2 + 1) - 1 do
     let d = d + i * 2 in
     let niter = 1 lsl (max_depth - d + min_depth) in
     let rec loop acc i num_domains =
       if i = num_domains then begin
-        List.rev acc |> List.iter (fun pr -> T.run pool (fun _ -> T.await pool pr))
-      end else begin 
-        loop 
-          ((T.async pool (fun _ -> 
+        List.rev acc |> List.iter (fun pr -> T.await pool pr)
+      end else begin
+        loop
+          ((T.async pool (fun _ ->
             calculate d (i * niter / num_domains) (((i + 1) * niter / num_domains) - 1) i)) :: acc) 
-          (i + 1) 
-          num_domains 
+          (i + 1)
+          num_domains
         end in
-    
+
     loop [] 0 num_domains;
     let _ = Array.fold_left (+) 0 values in
     ()
@@ -61,7 +60,8 @@ let loop_depths d =
   done
 
 let () =
-  loop_depths min_depth;
+  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  T.run pool (fun _ -> loop_depths min_depth pool);
   let _ = max_depth in
   let _ = (check long_lived_tree) in
   T.teardown_pool pool

--- a/benchmarks/multicore-numerical/nbody_multicore.ml
+++ b/benchmarks/multicore-numerical/nbody_multicore.ml
@@ -19,7 +19,6 @@ type planet = { mutable x : float;  mutable y : float;  mutable z : float;
                 mass : float }
 
 let advance pool bodies dt =
-  T.run pool (fun _ ->
     T.parallel_for pool
       ~start:0
       ~finish:(num_bodies - 1)
@@ -39,8 +38,7 @@ let advance pool bodies dt =
         done;
         b.vx <- !vx;
         b.vy <- !vy;
-        b.vz <- !vz)
-    );
+        b.vz <- !vz);
   for i = 0 to num_bodies - 1 do
     let b = bodies.(i) in
     b.x <- b.x +. dt *. b.vx;
@@ -49,7 +47,6 @@ let advance pool bodies dt =
   done
 
 let energy pool bodies =
-  T.run pool (fun _ ->
     T.parallel_for_reduce pool (+.) 0.
       ~start:0
       ~finish:(Array.length bodies -1)
@@ -63,7 +60,7 @@ let energy pool bodies =
           e := !e -. (b.mass *. b'.mass) /. distance;
         done;
       !e)
-    )
+
 
 let offset_momentum bodies =
   let px = ref 0. and py = ref 0. and pz = ref 0. in
@@ -90,7 +87,8 @@ let bodies =
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   offset_momentum bodies;
+  T.run pool (fun _ ->
   Printf.printf "%.9f\n" (energy pool bodies);
   for _i = 1 to n do advance pool bodies 0.01 done;
-  Printf.printf "%.9f\n" (energy pool bodies);
+  Printf.printf "%.9f\n" (energy pool bodies));
   T.teardown_pool pool

--- a/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
+++ b/benchmarks/multicore-numerical/spectralnorm2_multicore.ml
@@ -15,21 +15,19 @@ let eval_A i j = 1. /. float((i+j)*(i+j+1)/2+i+1)
 
 let eval_A_times_u pool u v =
   let n = Array.length v - 1 in
-  T.run pool (fun _ ->
     T.parallel_for ~start:0 ~finish:n
       ~body:(fun i ->
         let vi = ref 0. in
         for j = 0 to n do vi := !vi +. eval_A i j *. u.(j) done;
-        v.(i) <- !vi) pool)
+        v.(i) <- !vi) pool
 
 let eval_At_times_u pool u v =
   let n = Array.length v -1 in
-  T.run pool (fun _ ->
     T.parallel_for ~start:0 ~finish:n
       ~body:(fun i ->
         let vi = ref 0. in
         for j = 0 to n do vi := !vi +. eval_A j i *. u.(j) done;
-        v.(i) <- !vi) pool)
+        v.(i) <- !vi) pool
 
 let eval_AtA_times_u pool u v =
   let w = Array.make (Array.length u) 0.0 in
@@ -38,9 +36,10 @@ let eval_AtA_times_u pool u v =
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let u = Array.make n 1.0  and  v = Array.make n 0.0 in
+  T.run pool (fun _ ->
   for _i = 0 to 9 do
     eval_AtA_times_u pool u v; eval_AtA_times_u pool v u
-  done;
+  done);
   T.teardown_pool pool;
 
   let vv = ref 0.0  and  vBv = ref 0.0 in


### PR DESCRIPTION
Running `Task.pool` inside the iter function was blocking indefinitely, fixes #294.