### PR TITLE
Added dynamic package override and removal for Custom Support Variant

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -69,6 +69,8 @@ while [ $i -lt ${COUNT} ]; do
     CONFIG_RUN_PARAMS=`jq -r '.['$i'].runparams // empty' "${CUSTOM_FILE}"`
     CONFIG_ENVIRONMENT=`jq -r '.['$i'].environment // empty' "${CUSTOM_FILE}"`
     CONFIG_EXPIRY=`jq -r '.['$i'].expiry // empty' "${CUSTOM_FILE}"`
+    CONFIG_OVERRIDE_PACKAGES=`jq -r '.['$i'].override_packages // empty' "${CUSTOM_FILE}"`
+    CONFIG_REMOVE_PACKAGES=`jq -r '.['$i'].remove_packages // empty' "${CUSTOM_FILE}"`
     TAG_STRING=`echo \"${CONFIG_TAG}\"`
 
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)    
@@ -94,6 +96,8 @@ while [ $i -lt ${COUNT} ]; do
                              OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
                              OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
                              SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
+                             SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
+                             SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
                              make ocaml-versions/5.00.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
         else
             USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
@@ -102,6 +106,8 @@ while [ $i -lt ${COUNT} ]; do
                              OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
                              OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
                              SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
+                             SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
+                             SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
                              RUN_BENCH_TARGET=run_orunchrt \
                              BUILD_BENCH_TARGET=multibench_parallel \
                              make ocaml-versions/5.00.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1


### PR DESCRIPTION
The `SANDMARK_OVERRIDE_PACKAGES` and `SANDMARK_REMOVE_PACKAGES` can now be specified in the `custom.json` file for the Custom Support Variant. The same has been tested in a sample custom.json file with the following entries:
```
{
  "url": "https://github.com/ocaml/ocaml/archive/b73cbbea4bc40ffd26a459d594a39b99cec4273d.zip",
  "tag": "run_in_ci",
  "config_json": "run_config_filtered.json",
  "override_packages": "fmt.0.9.0 ocamlfind.1.9.3 checkseum.0.3.0",
  "remove_packages": "camlpdf cpdf coq coq-core coq-stdlib ctypes fraplib index integers irmin irmin-layers irmin-pack js_of_ocaml-compiler ppx_derivers ppx_deriving ppx_deriving_yojson ppx_irmin ppx_repr stdio",
 "name": "5.00+trunk+sequential",
  "expiry": "2100-01-01"
}
```
This should complete https://github.com/ocaml-bench/sandmark/issues/274.