### PR TITLE
Move nightly scripts to Sandmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,6 @@ check_url: check_jq
 			URL=`jq -r '.url' $$f`;                  			\
 			if [ -z "$$URL" ] ; then                  			\
 				echo "No URL (mandatory) for $$f";   			\
-				exit 1; 						\
 			else 								\
 				URL_EXISTS=`wget --spider $$URL 2>/dev/null; echo $$?`; \
 				if [ "$${URL_EXISTS}" != 0 ]; then 			\

--- a/nightly_navajo.sh
+++ b/nightly_navajo.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" bash run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" bash /home/sandmark/production/run_all_custom.sh
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/

--- a/nightly_navajo.sh
+++ b/nightly_navajo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# TOKEN required to commit to sandmark-nightly repository
+TOKEN=$1
+
+# The default Sandmark nightly directory
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR:-"/local/scratch/sandmark_nightly_workspace"}
+
+# Check if sandmark-nightly directory exists
+function check_sandmark_subdir {
+    if [ ! -d $1/sandmark-nightly ]; then
+        git clone -b testing https://$TOKEN@github.com/ocaml-bench/sandmark-nightly.git $1/sandmark-nightly
+    fi;
+}
+
+# Sandmark nightly directory
+if [ ! -d $SANDMARK_NIGHTLY_DIR ]; then 
+    mkdir $SANDMARK_NIGHTLY_DIR
+fi;
+
+# Check Sandmark nightly sub-directories
+check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
+
+# OPAM context
+eval $(opam env)
+
+# Run!
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" bash run_all_custom.sh
+
+# Push to sandmark-nightly
+cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/
+git pull origin testing
+git add .
+git commit -m "Automated commit (Navajo)"
+git push origin testing

--- a/nightly_turing.sh
+++ b/nightly_turing.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# TOKEN required to commit to sandmark-nightly repository
+TOKEN=$1
+
+# The default Sandmark nightly directory
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR:-"$HOME/production/sandmark_nightly_workspace"}
+
+# Check if sandmark-nightly directory exists
+function check_sandmark_subdir {
+    if [ ! -d $1/sandmark-nightly ]; then
+        git clone -b testing https://$TOKEN@github.com/ocaml-bench/sandmark-nightly.git $1/sandmark-nightly
+    fi;
+}
+
+# Sandmark nightly directory
+if [ ! -d $SANDMARK_NIGHTLY_DIR ]; then 
+    mkdir $SANDMARK_NIGHTLY_DIR
+fi;
+
+# Check Sandmark nightly sub-directories
+check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
+
+# OPAM context
+eval $(opam env)
+
+# Run!
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" bash run_all_custom.sh
+
+# Push to sandmark-nightly
+cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/
+git pull origin testing
+git add .
+git commit -m "Automated commit (Turing)"
+git push origin testing

--- a/nightly_turing.sh
+++ b/nightly_turing.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" bash run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" bash /home/sandmark/production/run_all_custom.sh
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/


### PR DESCRIPTION
This PR moves sandmark-nightly scripts to Sandmark. We need to deploy the nightly script along with the latest run_all_custom.sh script on the benchmarking machine.