### PR TITLE
Remove eventlog-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ START_TIME ?=
 
 WRAPPER = $(patsubst run_%,%,$(RUN_BENCH_TARGET))
 
-PACKAGES = sexplib0 re yojson react uuidm cpdf nbcodec minilight cubicle orun rungen eventlog-tools
+PACKAGES = sexplib0 re yojson react uuidm cpdf nbcodec minilight cubicle orun rungen
 
 ifeq ($(findstring multibench,$(BUILD_BENCH_TARGET)),multibench)
 	PACKAGES +=  lockfree kcas domainslib ctypes
@@ -136,7 +136,6 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 		*5.0*) opam pin add -n --yes --switch $* sexplib0.v0.15.0 https://github.com/shakthimaan/sexplib0.git#multicore; \
 	esac };
 	opam pin add -n --yes --switch $* base.v0.14.3 https://github.com/janestreet/base.git#v0.14.3
-	opam pin add -n --yes --switch $* eventlog-tools https://github.com/ocaml-multicore/eventlog-tools.git#multicore
 	opam pin add -n --yes --switch $* coq-core https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
 	opam pin add -n --yes --switch $* coq-stdlib https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
 


### PR DESCRIPTION
Remove `eventlog-tools` from the Makefile. We will eventually move to using `eventring` for tracing.