### PR TITLE
Fix nqueens failure

### DIFF
--- a/benchmarks/multicore-numerical/dune
+++ b/benchmarks/multicore-numerical/dune
@@ -85,6 +85,7 @@
 
 (executable
  (name nqueens)
+ (modes native byte)
  (modules nqueens))
 
 (executable

--- a/benchmarks/multicore-numerical/nqueens_multicore.ml
+++ b/benchmarks/multicore-numerical/nqueens_multicore.ml
@@ -46,7 +46,7 @@ let board_size = try int_of_string Sys.argv.(2) with _ -> 13
 
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
-  let n_solutions = nqueens pool board_size 0 [] in
+  let n_solutions = T.run pool (fun () -> nqueens pool board_size 0 []) in
   T.teardown_pool pool;
 
   Printf.printf "%i solutions for board of size %i\n" n_solutions board_size

--- a/run_config_byte.json
+++ b/run_config_byte.json
@@ -209,6 +209,15 @@
       ]
     },
     {
+      "executable": "benchmarks/multicore-numerical/nqueens.bc",
+      "name": "nqueens.bc",
+      "runs": [
+        {
+          "params": "15"
+        }
+      ]
+    },
+    {
       "executable": "benchmarks/valet/test_lwt.bc",
       "name": "test_lwt.bc",
       "runs": [


### PR DESCRIPTION
Adds a toplevel run to fix nqueens failure [encountered on sandmark nightly](https://github.com/ocaml-bench/sandmark-nightly/blob/main/parallel/navajo/20220418_004352/949e2626c22b5fe8159cb29d47207d5621eabf90/5.00%2Btrunk%2Bparallel.20220418_004352.949e2626c22b5fe8159cb29d47207d5621eabf90.log).

Also adds nqueens to bytebench config.