### PR TITLE
Use -alpha dune.2.9.3 to build with May 30, 2022 trunk

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,8 @@ steps:
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
-  - opam install dune.2.9.0
+  - opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+  - opam install dune
   - eval $(opam env)
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
@@ -40,7 +41,8 @@ steps:
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
-  - opam install dune.2.9.0
+  - opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+  - opam install dune
   - eval $(opam env)
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
@@ -68,7 +70,8 @@ steps:
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
-  - opam install dune.2.9.0
+  - opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+  - opam install dune
   - eval $(opam env)
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true
@@ -94,7 +97,8 @@ steps:
   - sudo chown -R opam .
   - eval $(opam env)
   - opam update
-  - opam install dune.2.9.0
+  - opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+  - opam install dune
   - eval $(opam env)
   - export ITER=1
   - export OPAM_DISABLE_SANDBOXING=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,8 @@ jobs:
           pip3 install intervaltree
           eval $(opam env)
           opam update
-          opam install dune.2.9.0
+          opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -54,7 +55,8 @@ jobs:
           pip3 install intervaltree
           eval $(opam env)
           opam update
-          opam install dune.2.9.0
+          opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -72,7 +74,8 @@ jobs:
           pip3 install intervaltree
           eval $(opam env)
           opam update
-          opam install dune.2.9.0
+          opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -88,7 +91,8 @@ jobs:
           pip3 install intervaltree
           eval $(opam env)
           opam update
-          opam install dune.2.9.0
+          opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 	opam pin add -n --yes --switch $* base.v0.14.3 https://github.com/janestreet/base.git#v0.14.3
 	opam pin add -n --yes --switch $* coq-core https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
 	opam pin add -n --yes --switch $* coq-stdlib https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
+	opam pin add -n --yes --switch $* ocamlfind https://github.com/dra27/ocamlfind/archive/lib-layout.tar.gz
 
 override_packages/%: setup_sys_dune/%
 	$(eval CONFIG_SWITCH_NAME = $*)

--- a/ocaml-versions/5.0.0+stable.json
+++ b/ocaml-versions/5.0.0+stable.json
@@ -1,8 +1,8 @@
 {
-  "url" : "https://github.com/ocaml/ocaml/archive/2422a5984a8cc597a44c214946677e562d8808bf.zip",
+  "url" : "https://github.com/ocaml/ocaml/archive/09ed8dfa28fd1d4a6576aac0ada6d1e0fde7a0e7.zip",
   "package_overrides": [
     "fmt.0.9.0",
-    "ocamlfind.1.9.3"
+    "ocamlfind.1.9.3.git"
   ],
   "package_remove": [
     "camlpdf",

--- a/ocaml-versions/5.0.0+trunk.json
+++ b/ocaml-versions/5.0.0+trunk.json
@@ -2,7 +2,7 @@
   "url" : "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
   "package_overrides": [
     "fmt.0.9.0",
-    "ocamlfind.1.9.3"
+    "ocamlfind.1.9.3.git"
   ],
   "package_remove": [
     "camlpdf",


### PR DESCRIPTION
* Use `dune.2.9.3 `from -alpha repository due to restructure of LIBDIR from https://github.com/ocaml/ocaml/pull/11198
* Update `.drone.yml` and GitHub Actions `main.yml` to pin and use dune.2.9.3
* Add `ocamlfind.1.9.3.git` from -alpha repository to build trunk from May 30, 2022.
* Update -stable to May 30, 2022 SHA1 commit.