### PR TITLE
Build/support for 4.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,40 @@ jobs:
           OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.1.0+trunk.bench
           ls _results
           cat _results/*
-          
+
+      - name: 4.14.0+serial
+        run: |
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
+          pip3 install intervaltree
+          opam update
+          opam install dune.2.9.0
+          eval $(opam env)
+          export ITER=1
+          export OPAM_DISABLE_SANDBOXING=true
+          TAG='"run_in_ci"' make run_config_filtered.json
+          sed -i 's/--cpu-list 5/--cpu-list 1/g' run_config_filtered.json
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.14.0.bench
+          ls _results
+          cat _results/*
+
+      - name: 4.14.0+parallel
+        run: |
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
+          pip3 install intervaltree
+          opam update
+          opam install dune.2.9.0
+          eval $(opam env)
+          export ITER=1
+          export OPAM_DISABLE_SANDBOXING=true
+          TAG='"run_in_ci"' make multicore_parallel_run_config_filtered.json
+          TAG='"macro_bench"' make multicore_parallel_run_config_filtered_filtered.json
+          sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered.json
+          sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered_filtered.json
+          make multicore_parallel_run_config_filtered_filtered_2domains.json
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.14.0.bench
+          ls _results
+          cat _results/*
+
       - name: test_notebooks
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip jo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-5.1:
+  build-5-1:
     strategy:
       matrix:
         os:
@@ -118,7 +118,7 @@ jobs:
           sudo chmod 777 .
           jupyter nbconvert --to html --execute parallel.ipynb
 
-  build-4.14:
+  build-4-14:
     strategy:
       matrix:
         os:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  build-5.1:
     strategy:
       matrix:
         os:
@@ -105,6 +105,40 @@ jobs:
           ls _results
           cat _results/*
 
+      - name: test_notebooks
+        run: |
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip jo
+          python3 -m pip install markupsafe==2.0.1
+          export PATH=$PATH:/home/opam/.local/bin
+          pip3 install jupyter nbconvert seaborn pandas
+          cd notebooks/sequential
+          sudo chmod 777 .
+          jupyter nbconvert --to html --execute sequential.ipynb
+          cd ../parallel
+          sudo chmod 777 .
+          jupyter nbconvert --to html --execute parallel.ipynb
+
+  build-4.14:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
       - name: 4.14.0+serial
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
@@ -137,16 +171,3 @@ jobs:
           OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.14.0.bench
           ls _results
           cat _results/*
-
-      - name: test_notebooks
-        run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip jo
-          python3 -m pip install markupsafe==2.0.1
-          export PATH=$PATH:/home/opam/.local/bin
-          pip3 install jupyter nbconvert seaborn pandas
-          cd notebooks/sequential
-          sudo chmod 777 .
-          jupyter nbconvert --to html --execute sequential.ipynb
-          cd ../parallel
-          sudo chmod 777 .
-          jupyter nbconvert --to html --execute parallel.ipynb

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,11 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 override_packages/%: setup_sys_dune/%
 	$(eval CONFIG_SWITCH_NAME = $*)
 	$(eval DEV_OPAM = $(OPAMROOT)/$(CONFIG_SWITCH_NAME)/share/dev.opam)
+	@{ case "$*" in \
+		*4.14*) cp dependencies/template/dev-4.14.0.opam $(DEV_OPAM) ;; \
+		*) cp dependencies/template/dev.opam $(DEV_OPAM) ;; \
+	esac };
 	opam repo add upstream "https://opam.ocaml.org" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
-	cp dependencies/template/dev.opam $(DEV_OPAM)
 ifeq (0, $(USE_SYS_DUNE_HACK))
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes "dune.$(SANDMARK_DUNE_VERSION)" "dune-configurator.$(SANDMARK_DUNE_VERSION)" "dune-private-libs.$(SANDMARK_DUNE_VERSION)" || $(CONTINUE_ON_OPAM_INSTALL_ERROR)
 endif

--- a/dependencies/template/dev-4.14.0.opam
+++ b/dependencies/template/dev-4.14.0.opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+name: "Sandmark"
+synopsis: "Sandmark benchmark suite"
+maintainer: "Shakthi Kannan <author@shakthimaan.com>"
+authors: "Shakthi Kannan <author@shakthimaan.com>"
+homepage: "https://github.com/ocaml-bench/sandmark"
+bug-reports: "https://github.com/ocaml-bench/sandmark/issues"
+license: "CC 1.0 Universal"
+depends: [
+  "astring" {= "0.8.5"}
+  "base64" {= "3.4.0"}
+  "bigstringaf" {= "0.6.1"}
+  "camlp-streams" {= "5.0.1"}
+  "checkseum" {= "0.2.1"}
+  "conf-findutils" {= "1"}
+  "conf-gmp" {= "1"}
+  "conf-m4" {= "1"}
+  "conf-perl" {= "1"}
+  "conf-pkg-config" {= "1.2"}
+  "cppo" {= "1.6.7"}
+  "ctypes" {= "0.15.0"}
+  "decompress" {= "1.1.0"}
+  "digestif" {= "1.0.0"}
+  "fmt" {= "0.8.9"}
+  "index" {= "1.3.0"}
+  "integers" {= "0.4.0"}
+  "irmin" {= "2.4.0"}
+  "irmin-layers" {= "2.4.0"}
+  "irmin-pack" {= "2.4.0"}
+  "logs" {= "0.7.0"}
+  "lwt" {= "5.4.0"}
+  "menhir" {= "20200612"}
+  "menhirLib" {= "20200612"}
+  "menhirSdk" {= "20200612"}
+  "mtime" {= "1.2.0"}
+  "num" {= "1.3"}
+  "ocaml-config" {= "1"}
+  "ocamlgraph" {= "2.0.0"}
+  "optint" {= "0.0.4"}
+  "psmt2-frontend" {= "0.2"}
+  "repr" {= "0.2.1"}
+  "rresult" {= "0.6.0"}
+  "stdio" {= "v0.14.0"}
+  "stdlib-shims" {= "0.1.0"}
+  "topkg" {= "1.0.3"}
+  "uri" {= "4.1.0"}
+  "zarith" {= "1.10"}
+]

--- a/ocaml-versions/4.14.0.json
+++ b/ocaml-versions/4.14.0.json
@@ -1,0 +1,28 @@
+{
+  "url" : "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.0.zip",
+  "package_remove": [
+    "camlpdf",
+    "cpdf",
+    "coq",
+    "coq-core",
+    "coq-stdlib",
+    "ctypes",
+    "frama-c",
+    "fraplib",
+    "index",
+    "integers",
+    "irmin",
+    "irmin-layers",
+    "irmin-pack",
+    "js_of_ocaml-compiler",
+    "ppx_derivers",
+    "ppx_deriving",
+    "ppx_deriving_yojson",
+    "ppx_irmin",
+    "ppx_repr",
+    "ppxfind",
+    "ppxlib",
+    "ppxtools",
+    "stdio"
+  ]
+}

--- a/ocaml-versions/4.14.1+trunk.json
+++ b/ocaml-versions/4.14.1+trunk.json
@@ -1,0 +1,28 @@
+{
+  "url" : "https://github.com/ocaml/ocaml/archive/4.14.tar.gz",
+  "package_remove": [
+    "camlpdf",
+    "cpdf",
+    "coq",
+    "coq-core",
+    "coq-stdlib",
+    "ctypes",
+    "frama-c",
+    "fraplib",
+    "index",
+    "integers",
+    "irmin",
+    "irmin-layers",
+    "irmin-pack",
+    "js_of_ocaml-compiler",
+    "ppx_derivers",
+    "ppx_deriving",
+    "ppx_deriving_yojson",
+    "ppx_irmin",
+    "ppx_repr",
+    "ppxfind",
+    "ppxlib",
+    "ppxtools",
+    "stdio"
+  ]
+}

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -80,6 +80,7 @@ while [ $i -lt ${COUNT} ]; do
         # Obtain configuration options
         CONFIG_URL=`jq -r '.['$i'].url' "${CUSTOM_FILE}"`
         CONFIG_NAME=`jq -r '.['$i'].name' "${CUSTOM_FILE}"`
+        CONFIG_VARIANT="$(cut -d '+' -f 1 <<< "$CONFIG_NAME")"
         CONFIG_EXPIRY=`jq -r '.['$i'].expiry // empty' "${CUSTOM_FILE}"`
         CONFIG_TAG=`jq -r '.['$i'].tag // "macro_bench"' "${CUSTOM_FILE}"`
 
@@ -131,7 +132,7 @@ while [ $i -lt ${COUNT} ]; do
                                  SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
                                  SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
                                  SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
-                                 make ocaml-versions/5.1.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
+                                 make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
             else
                 USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
                                  RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
@@ -143,7 +144,7 @@ while [ $i -lt ${COUNT} ]; do
                                  SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
                                  RUN_BENCH_TARGET=run_orunchrt \
                                  BUILD_BENCH_TARGET=multibench_parallel \
-                                 make ocaml-versions/5.1.0+stable.bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
+                                 make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
             fi
 
             # Copy results


### PR DESCRIPTION
* Added support for 4.14 to build with Sandmark-nightly.
  Reference: https://github.com/ocaml-bench/sandmark-nightly-config/pull/5
* A separate dev.opam file has been created for 4.14, which can be useful when we move to using monorepo.
* Both 4.14.0 and 4.14.1+trunk are supported.
* The GitHub Actions CI has been updated to build for 4.14.0 as well.