### PR TITLE
Use git+https for opam remote repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 override_packages/%: setup_sys_dune/%
 	$(eval CONFIG_SWITCH_NAME = $*)
 	$(eval DEV_OPAM = $(OPAMROOT)/$(CONFIG_SWITCH_NAME)/share/dev.opam)
-	opam repo add upstream "https://opam.ocaml.org" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
+	opam repo add upstream "git+https://github.com/ocaml/opam-repository.git" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
 	cp dependencies/template/dev.opam $(DEV_OPAM)
 ifeq (0, $(USE_SYS_DUNE_HACK))
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes "dune.$(SANDMARK_DUNE_VERSION)" "dune-configurator.$(SANDMARK_DUNE_VERSION)" "dune-private-libs.$(SANDMARK_DUNE_VERSION)" || $(CONTINUE_ON_OPAM_INSTALL_ERROR)


### PR DESCRIPTION
Use `git+https` for adding opam remote repository because:
1. The "null update" is much faster when compared to https, as it is a git pull followed by a SHA comparison.
2. In opam 3.x, the HTTP remote will be removed.