### PR TITLE
Fix execution of Graph500 benchmarks

### DIFF
--- a/benchmarks/graph500par/dune
+++ b/benchmarks/graph500par/dune
@@ -35,6 +35,11 @@
   (libraries graphTypes generate kernel1Par unix domainslib)
 )
 
+(rule
+  (targets edges.data)
+  (deps (:prog gen.exe))
+  (action (run %{prog} -scale 21 -edgefactor 16 -ndomains 16 %{targets})))
+
 (alias
   (name multibench_parallel)
-  (deps gen.exe kernel1_run_multicore.exe))
+  (deps kernel1_run_multicore.exe edges.data))

--- a/benchmarks/graph500seq/dune
+++ b/benchmarks/graph500seq/dune
@@ -37,8 +37,12 @@
   (libraries graphTypes generateSeq kernel1Seq unix)
 )
 
+(rule
+  (targets edges.data)
+  (deps (:prog gen.exe))
+  (action (run %{prog} -scale 21 -edgefactor 16 %{targets})))
+
 (alias
   (name buildbench)
-  (deps kronecker.exe kernel2.exe kernel3.exe
-        gen.exe kernel1_run.exe)
+  (deps kronecker.exe kernel2.exe kernel3.exe kernel1_run.exe edges.data)
 )

--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -128,6 +128,44 @@
       ]
     },
     {
+      "executable": "benchmarks/graph500par/gen.exe",
+      "name": "graph500_par_gen",
+      "tags": [ "macro_bench", "10s_100s" ],
+      "runs": [
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 1 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 2 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 4 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 8 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 12 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 16 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 20 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 24 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+      ]
+    },
+    {
+      "executable": "benchmarks/graph500seq/kernel1_run.exe",
+      "name": "graph500_seq_kernel1",
+      "tags": ["macro_bench"],
+      "runs": [
+        { "params": "edges.data" , "paramwrapper": "taskset --cpu-list 2-13"}
+      ]
+    },
+    {
+      "executable": "benchmarks/graph500par/kernel1_run_multicore.exe",
+      "name": "graph500_par_kernel1",
+      "tags": [ "10s_100s", "macro_bench" ],
+      "runs": [
+	{ "params": "-ndomains 1 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-ndomains 2 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-ndomains 4 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-ndomains 8 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-ndomains 12 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-ndomains 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-ndomains 20 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-ndomains 24 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+      ]
+    },
+    {
       "executable": "benchmarks/benchmarksgame/mandelbrot6.exe",
       "name": "mandelbrot6",
       "tags": [

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -111,26 +111,18 @@
       ]
     },
     {
-      "executable": "benchmarks/graph500par/generateSeq.exe",
-      "name": "spectralnorm2",
-      "tags": ["macro_bench"],
-      "runs": [
-        { "params": "-scale 21 -edgefactor 16 edges.data" , "paramwrapper": "taskset --cpu-list 2-13"}
-      ]
-    },
-    {
       "executable": "benchmarks/graph500par/gen.exe",
       "name": "graph500_par_gen",
       "tags": [ "macro_bench", "10s_100s" ],
       "runs": [
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 1 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 2 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 4 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 8 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 12 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 20 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-	{ "params": "-scale 21 -edgefactor 16 -ndomains 24 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 1 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 2 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 4 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 8 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 12 /dev/null", "paramwrapper": "taskset --cpu-list 2-13" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 16 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 20 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
+	{ "params": "-scale 21 -edgefactor 16 -ndomains 24 /dev/null", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
       ]
     },
     {

--- a/run_config.json
+++ b/run_config.json
@@ -68,16 +68,6 @@
       ]
     },
     {
-      "executable": "benchmarks/graph500seq/gen.exe",
-      "name": "graph500_seq_gen",
-      "tags": [ "10s_100s" ],
-      "runs": [
-	{
-	  "params": "-scale 21 -edgefactor 16 edges.data"
-	}
-      ]
-    },
-    {
       "executable": "benchmarks/graph500seq/kernel1_run.exe",
       "name": "graph500_seq_kernel1",
       "tags": [ "10s_100s", "macro_bench" ],


### PR DESCRIPTION
Currently the benchmarks `graph500par/kernel1_run` and `graph500seq/kernel1_run` fail because they depend on a file `edges.data` which should be generated first. This is an attempt to fix it by generating `edges.data` using dune rules.