### PR TITLE
Using sandmark inside current-bench

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,14 +1,15 @@
 FROM ocaml/opam:ubuntu-20.04-ocaml-4.12
 
-ENV BENCHCMD="TAG='\"run_in_ci\"' $(MAKE) run_config_filtered.json; RUN_CONFIG_JSON=run_config_filtered.json $(MAKE) ocaml-versions/4.14.0+domains.bench"
+ENV BENCHCMD="TAG='\"run_in_ci\"' $(MAKE) run_config_filtered.json; USE_SYS_DUNE_HACK=1 OPT_WAIT=0 RUN_CONFIG_JSON=run_config_filtered.json $(MAKE) ocaml-versions/5.1.0+trunk.bench"
 
 WORKDIR /app
 
 RUN sudo apt-get update
-RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf
+RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf gnuplot
 
 RUN opam update
-RUN opam install dune.2.9.0
+RUN opam pin add -n --yes dune https://github.com/dra27/dune/archive/2.9.3-5.0.0.tar.gz
+RUN opam install dune
 
 COPY . .
 


### PR DESCRIPTION
This PR allows the `make bench` command to run sequential benchmarks and record the results in a way that will be consumed by current-bench.
The last thing needed is to enroll the ocaml-bench organisation into the [github app ocaml-benchmarks](https://github.com/marketplace/ocaml-benchmarksv) if that wasn't done already, and to activate it on the sandmark repository.