### PR TITLE
Use a different custom file on reach run

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -4,7 +4,7 @@
 CUSTOM_FILE=${CUSTOM_FILE:-"ocaml-versions/custom.json"}
 SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR:-/tmp}
 SANDMARK_REPO="https://github.com/ocaml-bench/sandmark.git"
-TMP_CUSTOM_FILE="/tmp/custom.json"
+TMP_CUSTOM_FILE=$(mktemp --tmpdir custom.XXXXXXXX.json)
 TMP_DIR="/tmp"
 
 # Host


### PR DESCRIPTION
This would allow failures when a `/tmp/custom.json` already exists and the sandmark user doesn't have write permissions to the file.