### PR TITLE
Fix warnings on sequential build bench

### DIFF
--- a/benchmarks/chameneos/chameneos_redux_lwt.ml
+++ b/benchmarks/chameneos/chameneos_redux_lwt.ml
@@ -118,7 +118,7 @@ module Chameneos = struct
         t.meetings <- t.meetings + 1;
         if t.id = other.id then t.meetings_with_self <- t.meetings_with_self + 1;
         t.color <- Color.complement t.color other.color;
-        Lwt_main.yield () >>= fun () ->
+        Lwt.pause () >>= fun () ->
         loop ()
     in
     loop ()

--- a/benchmarks/lexifi-g2pp/optimization.ml
+++ b/benchmarks/lexifi-g2pp/optimization.ml
@@ -232,7 +232,7 @@ let least_squares
       let call_back =
         match feedback with
         | None -> fun _ _ -> ()
-        | Some f -> (fun evals dist -> Printf.kprintf f "Global Optimizer   Evals: %5i   RMS: %12.8g%%" evals (rms_of_error dist))
+        | Some f -> (fun evals dist -> Printf.ksprintf f "Global Optimizer   Evals: %5i   RMS: %12.8g%%" evals (rms_of_error dist))
       in
       let f x =
         pricer (parameters_of_active_vars x) prices;

--- a/benchmarks/multicore-lockfree/wsqueue-dune.inc
+++ b/benchmarks/multicore-lockfree/wsqueue-dune.inc
@@ -1,11 +1,11 @@
 (executable
 	(name test_wsqueue)
 	(modules test_wsqueue)
-	(libraries lockfree))
+	(libraries lockfree unix))
 
 (executable
 	(name test_wsqueue_multicore)
 	(modules test_wsqueue_multicore)
-	(libraries lockfree))
+	(libraries lockfree unix))
 
 (alias (name multibench_parallel) (deps test_wsqueue.exe test_wsqueue_multicore.exe))

--- a/benchmarks/numerical-analysis/dune
+++ b/benchmarks/numerical-analysis/dune
@@ -1,7 +1,7 @@
 ;; Adapted from OCamlPro's ocamlbench-repo
 ;; See https://github.com/OCamlPro/ocamlbench-repo
 (executable (name durand_kerner_aberth) (modes native byte) (modules durand_kerner_aberth))
-(executable (name fft) (modes native byte) (modules fft))
+(executable (name fft) (modes native byte) (modules fft) (libraries unix))
 (executable (name crout_decomposition) (modes native byte) (modules crout_decomposition))
 (executable (name qr_decomposition) (modes native byte) (modules qr_decomposition))
 

--- a/benchmarks/sauvola/dune
+++ b/benchmarks/sauvola/dune
@@ -2,6 +2,6 @@
 ;; See https://github.com/OCamlPro/ocamlbench-repo
 (executable
  (name contrast)
- (libraries camlimages.all_formats))
+ (libraries camlimages.all_formats unix))
 
 (alias (name bench) (deps contrast.exe))

--- a/benchmarks/valet/test_lib.ml
+++ b/benchmarks/valet/test_lib.ml
@@ -16,7 +16,7 @@ end = struct
 
   let create () =
       {
-        id = Uuidm.create `V4;
+        id = Uuidm.v `V4;
         handler = Handler.create_sensor ();
       }
 
@@ -43,7 +43,7 @@ end = struct
 
   let create db =
     {
-      id = Uuidm.create `V4;
+      id = Uuidm.v `V4;
       handler = Handler.create
           (fun evt -> match Event.event evt with
              | `QRCode qr ->
@@ -80,7 +80,7 @@ end = struct
     }
 
   let create ~readers ~action =
-    let id = Uuidm.create `V4 in
+    let id = Uuidm.v `V4 in
       {
         id;
         readers;

--- a/benchmarks/valet/test_lwt.ml
+++ b/benchmarks/valet/test_lwt.ml
@@ -26,7 +26,7 @@ end = struct
       | n ->
         let r = readers.(Random.int len) in
         QRReader.use r t.qrcode;
-        Lwt_main.yield () >>= fun () ->
+        Lwt.pause () >>= fun () ->
         run @@ pred n
     in run n
 end


### PR DESCRIPTION
Close https://github.com/ocaml-bench/sandmark/issues/398

Confirmed there are no warnings left when building sequential benchmarks on Navajo with 5.1.0+trunk