### PR TITLE
Remove explicit dependency on a topkg version

### DIFF
--- a/dependencies/template/dev-5.1.0+trunk.opam
+++ b/dependencies/template/dev-5.1.0+trunk.opam
@@ -37,7 +37,6 @@ depends: [
   "repr" {= "0.6.0"}
   "rresult" {= "0.6.0"}
   "stdlib-shims" {= "0.1.0"}
-  "topkg" {= "1.0.3"}
   "uri" {= "4.1.0"}
   "zarith" {= "1.10"}
 ]

--- a/dependencies/template/dev.opam
+++ b/dependencies/template/dev.opam
@@ -42,7 +42,6 @@ depends: [
   "repr" {= "0.6.0"}
   "rresult" {= "0.6.0"}
   "stdlib-shims" {= "0.1.0"}
-  "topkg" {= "1.0.3"}
   "uri" {= "4.1.0"}
   "zarith" {= "1.10"}
 ]


### PR DESCRIPTION
topkg is already a transitive dependency and a new release of topkg and updates to it's dependencies caused the build to fail. This commit drops the explicit dependency on topkg and lets opam install it based on the other dependencies.