### PR TITLE
Fix typo in mergesort executable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ filter/%:
 	@echo $(CONFIG_VARIANT)
 	if [ $(CONFIG_VARIANT) = "5.1.0" ]; then \
 		echo "Filtering some benchmarks for OCaml v5.1.0"; \
-		jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select( .name as $$name | ["irmin_replay", "cpdf", "frama-c", "mergesort", "js_of_ocaml", "graph500_par_gen"] | index($$name) | not )]}' $(RUN_CONFIG_JSON) > $(RUN_CONFIG_JSON).tmp; \
+		jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select( .name as $$name | ["irmin_replay", "cpdf", "frama-c", "js_of_ocaml", "graph500_par_gen"] | index($$name) | not )]}' $(RUN_CONFIG_JSON) > $(RUN_CONFIG_JSON).tmp; \
 		mv $(RUN_CONFIG_JSON).tmp $(RUN_CONFIG_JSON); \
 		echo "(data_only_dirs irmin cpdf frama-c)" > benchmarks/dune; \
 	fi;

--- a/run_config.json
+++ b/run_config.json
@@ -280,7 +280,7 @@
       ]
     },
     {
-      "executable": "benchmarks/multicore-numerical/mergersort.exe",
+      "executable": "benchmarks/multicore-numerical/mergesort.exe",
       "name": "mergesort",
       "tags": [
         "1s_10s",


### PR DESCRIPTION
05f9527357fddf25bc2a5bdebe87bdaed418a124 tried to fix a typo, but introduced another. This commit fixes problems with running mergesort benchmark