### PR TITLE
Build kernel1_run.exe when running parallel benchmarks too

### DIFF
--- a/benchmarks/graph500seq/dune
+++ b/benchmarks/graph500seq/dune
@@ -46,3 +46,7 @@
   (name buildbench)
   (deps kronecker.exe kernel2.exe kernel3.exe kernel1_run.exe edges.data)
 )
+
+(alias
+  (name multibench_parallel)
+  (deps kernel1_run.exe edges.data))


### PR DESCRIPTION
Fixes an error with running the graph500 benchmarks when running parallel benchmarks.