### PR TITLE
Upgrade dune to 3.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,6 @@ jobs:
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
-          opam update
-          opam pin add -n --yes dune 3.5.0
-          opam install dune
-          eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
           TAG='"run_in_ci"' make run_config_filtered.json
@@ -57,10 +53,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
           pip3 install intervaltree
-          eval $(opam env)
-          opam update
-          opam pin add -n --yes dune 3.5.0
-          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -78,10 +70,6 @@ jobs:
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
-          opam update
-          opam pin add -n --yes dune 3.5.0
-          opam install dune
-          eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
           TAG='"run_in_ci"' make run_config_filtered.json
@@ -95,10 +83,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
           pip3 install intervaltree
-          eval $(opam env)
-          opam update
-          opam pin add -n --yes dune 3.5.0
-          opam install dune
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_BENCH_TARGET ?= buildbench
 RUN_CONFIG_JSON ?= run_config.json
 
 # Default dune version to be used
-SANDMARK_DUNE_VERSION ?= 2.9.0
+SANDMARK_DUNE_VERSION ?= 3.5.0
 
 # Default URL
 SANDMARK_URL ?= ""
@@ -106,6 +106,7 @@ ifeq (1, $(USE_SYS_DUNE_HACK))
 	ln -s $(SYS_DUNE_BASE_DIR)/bin/dune $(CURDIR)/_opam/sys_dune/bin/dune
 	ln -s $(SYS_DUNE_BASE_DIR)/bin/jbuilder $(CURDIR)/_opam/sys_dune/bin/jbuilder
 	ln -s $(SYS_DUNE_BASE_DIR)/lib/dune $(CURDIR)/_opam/sys_dune/lib/dune
+	opam repo add upstream "git+https://github.com/ocaml/opam-repository.git" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes ocamlfind
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes "dune.$(SANDMARK_DUNE_VERSION)" "dune-configurator.$(SANDMARK_DUNE_VERSION)"
 	# Pin the version so it doesn't change when installing packages
@@ -166,7 +167,6 @@ override_packages/%: setup_sys_dune/%
 			$(eval PACKAGES += runtime_events_tools) ;; \
 	    *) echo "Pausetimes unavailable for OCaml < 5" ;; \
 	esac };
-	opam repo add upstream "git+https://github.com/ocaml/opam-repository.git" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
 	opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git --on-switch=$(CONFIG_SWITCH_NAME) --rank 2
 	opam exec --switch $(CONFIG_SWITCH_NAME) -- opam update
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes "lru" "psq"

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,6 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 	@{ case "$*" in \
 		*5.1*) opam pin add -n --yes --switch $* sexplib0.v0.15.0 https://github.com/shakthimaan/sexplib0.git#multicore; \
 	esac };
-	# TODO remove when switching to dune 3
-	opam pin add -n --yes --switch $* hdr_histogram https://github.com/Firobe/hdr_histogram_ocaml.git
-	# TODO remove when switching to dune 3
-	opam pin add -n --yes --switch $* runtime_events_tools https://github.com/Firobe/runtime_events_tools.git
 	# TODO remove pin when a new orun version is released on opam
 	opam pin add -n --yes --switch $* orun https://github.com/ocaml-bench/orun.git
 	opam pin add -n --yes --switch $* ocamlfind https://github.com/dra27/ocamlfind/archive/lib-layout.tar.gz

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -7,10 +7,6 @@ WORKDIR /app
 RUN sudo apt-get update
 RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf gnuplot libffi-dev cmake
 
-RUN opam update
-RUN opam pin add -n --yes dune 3.5.0
-RUN opam install dune
-
 COPY . .
 
 RUN sudo chown -R opam /app

--- a/dependencies/template/dev-5.1.0+trunk.opam
+++ b/dependencies/template/dev-5.1.0+trunk.opam
@@ -23,7 +23,9 @@ depends: [
   "cppo" {= "1.6.7"}
   "decompress" {= "1.1.0"}
   "digestif" {= "1.0.0"}
+  "domainslib" {= "0.4.2"}
   "fmt" {= "0.9.0"}
+  "lockfree" {= "0.1.3"}
   "logs" {= "0.7.0"}
   "lwt" {= "5.6.1"}
   "menhir" {= "20200612"}


### PR DESCRIPTION
This PR removes the special version of dune installation for CI and use the same
installation procedure as actual benchmark runs for CI as well, and upgrades the 
version of dune to 3.5.0

Without this PR, errors occur when trying to install hdr_histogram during the [nightly runs](https://github.com/ocaml-bench/sandmark-nightly/commit/6823fbf8d8fa97a68ee8bf78b5297c1eab402763#diff-b7ac490c32e826964443ee723c3a98f72f454e782fddb1e17c0aa7efeb12f05aR463-R477) (Expand the first diff to jump to the exact lines)