### PR TITLE
Fix bench.Dockerfile to allow running chrt for parallel benchmarks

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -10,6 +10,7 @@ RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4
 COPY . .
 
 RUN sudo chown -R opam /app
+RUN sudo setcap cap_sys_nice=ep /usr/bin/chrt
 RUN eval $(opam env)
 
 RUN export ITER=1


### PR DESCRIPTION
The Benchmarks section in the README documents this command to correctly run parallel benchmarks. We don't yet run it in Current bench, but this will make us future-proof.