### PR TITLE
Add pausetimes to nightly runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ _opam/%: _opam/opam-init/init.sh ocaml-versions/%.json
 	esac };
 	# TODO remove pin when a new orun version is released on opam
 	opam pin add -n --yes --switch $* orun https://github.com/ocaml-bench/orun.git
+	# TODO remove pin when a new runtime_events_tools is released on opam
+	opam pin add -n --yes --switch $* runtime_events_tools https://github.com/sadiqj/runtime_events_tools.git
 	opam pin add -n --yes --switch $* ocamlfind https://github.com/dra27/ocamlfind/archive/lib-layout.tar.gz
 	opam pin add -n --yes --switch $* base.v0.14.3 https://github.com/janestreet/base.git#v0.14.3
 	opam pin add -n --yes --switch $* coq-core https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -40,12 +40,12 @@ find_commit () {
 }
 
 is_old_commit () {
-    SEQPAR=$1
+    KIND=$1
     HOSTNAME=$2
     COMMIT=$3
     REPO_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly"
     git -C "${REPO_DIR}" checkout -B main origin/main
-    BENCH_PATH="${SEQPAR}/${HOSTNAME}/*/${COMMIT}/*.summary.bench"
+    BENCH_PATH="${KIND}/${HOSTNAME}/*/${COMMIT}/*.summary.bench"
     # NOTE: git ls-files doesn't change the exit code whether or not any files
     # are found. So, we grep for files with summary.bench in their name, and
     # use its exit code.
@@ -65,34 +65,49 @@ fi
 COUNT=`jq '. | length' "${CUSTOM_FILE}"`
 
 # Iterate through each variant
-i=0
-while [ $i -lt ${COUNT} ]; do
-    j=0
-    while [ $j -lt 3 ]; do
+for i in $(seq 0 $((${COUNT} - 1))); do
+    # Iterate through each kind of benchmark
+    for KIND in "sequential" "parallel" "perfstat" "pausetimes"; do
         # Obtain configuration options
         CONFIG_URL=`jq -r '.['$i'].url' "${CUSTOM_FILE}"`
         CONFIG_NAME=`jq -r '.['$i'].name' "${CUSTOM_FILE}"`
         CONFIG_VARIANT=$(grep -oP "(\\d|\.)+(\\+(trunk|stable))*" <<< "${CONFIG_NAME}")
         CONFIG_EXPIRY=`jq -r '.['$i'].expiry // empty' "${CUSTOM_FILE}"`
         CONFIG_TAG=`jq -r '.['$i'].tag // "macro_bench"' "${CUSTOM_FILE}"`
+        CONFIG_NAME="${CONFIG_NAME}+${KIND}"
 
-        if [ $j -eq 0 ]; then
-            CONFIG_RUN_JSON="run_config_filtered.json"
-            CONFIG_NAME="${CONFIG_NAME}+sequential"
-            SEQPAR="sequential"
-        elif [ $j -eq 2 ]; then
-            CONFIG_RUN_JSON="run_config_filtered.json"
-            CONFIG_NAME="${CONFIG_NAME}+perfstat"
-            SEQPAR="perfstat"
-        else
-            CONFIG_NAME="${CONFIG_NAME}+parallel"
-            if [ "${HOSTNAME}" == "navajo" ]; then
-                CONFIG_RUN_JSON="multicore_parallel_navajo_run_config_filtered.json"
-            else
-                CONFIG_RUN_JSON="multicore_parallel_run_config_filtered.json"
-            fi
-            SEQPAR="parallel"
-        fi
+        # Set configuration flags according to the kind of benchmark we're
+        # running
+        case ${KIND} in
+            sequential)
+                CONFIG_RUN_JSON="run_config_filtered.json"
+                CONFIG_RUN_BENCH_TARGET="run_orun"
+                CONFIG_BUILD_BENCH_TARGET="buildbench"
+                ;;
+            parallel)
+                CONFIG_RUN_BENCH_TARGET="run_orunchrt"
+                CONFIG_BUILD_BENCH_TARGET="multibench_parallel"
+                if [ "${HOSTNAME}" == "navajo" ]; then
+                    CONFIG_RUN_JSON="multicore_parallel_navajo_run_config_filtered.json"
+                else
+                    CONFIG_RUN_JSON="multicore_parallel_run_config_filtered.json"
+                fi
+                ;;
+            perfstat)
+                CONFIG_RUN_JSON="run_config_filtered.json"
+                CONFIG_RUN_BENCH_TARGET="run_perfstat"
+                CONFIG_BUILD_BENCH_TARGET="buildbench"
+                ;;
+            pausetimes)
+                CONFIG_RUN_JSON="run_config_filtered.json"
+                CONFIG_RUN_BENCH_TARGET="run_pausetimes"
+                CONFIG_BUILD_BENCH_TARGET="buildbench"
+                ;;
+            *)
+                echo "Unknown kind ${KIND}! Skipping"
+                continue
+                ;;
+        esac
 
         CONFIG_OPTIONS=`jq -r '.['$i'].configure // empty' "${CUSTOM_FILE}"`
         CONFIG_RUN_PARAMS=`jq -r '.['$i'].runparams // empty' "${CUSTOM_FILE}"`
@@ -107,9 +122,9 @@ while [ $i -lt ${COUNT} ]; do
 
         echo "INFO: ${TIMESTAMP} Running benchmarks for URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT}"
 
-        if [[ ! -z "${COMMIT}" ]] && check_not_expired ${CONFIG_EXPIRY} && ! is_old_commit "${SEQPAR}" "${HOSTNAME}" "${COMMIT}"; then
+        if [[ ! -z "${COMMIT}" ]] && check_not_expired ${CONFIG_EXPIRY} && ! is_old_commit "${KIND}" "${HOSTNAME}" "${COMMIT}"; then
             # Create results directory
-            RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${SEQPAR}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"
+            RESULTS_DIR="${SANDMARK_NIGHTLY_DIR}/sandmark-nightly/${KIND}/${HOSTNAME}/${TIMESTAMP}/${COMMIT}"
             mkdir -p "${RESULTS_DIR}"
 
             # Clone fresh copy of Sandmark
@@ -120,40 +135,17 @@ while [ $i -lt ${COUNT} ]; do
             TAG=`echo "${TAG_STRING}"` make `echo ${CONFIG_RUN_JSON}`
 
             # Build and execute benchmarks
-            if [[ ${SEQPAR} == "sequential" ]]; then
-                USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
-                                 RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
-                                 ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
-                                 OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
-                                 OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
-                                 SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
-                                 SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
-                                 SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
-                                 make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
-            elif [[ ${SEQPAR} == "perfstat" ]]; then
-                USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
-                                 RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
-                                 RUN_BENCH_TARGET="run_perfstat" \
-                                 ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
-                                 OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
-                                 OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
-                                 SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
-                                 SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
-                                 SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
-                                 make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
-            else
-                USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
-                                 RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
-                                 ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
-                                 OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
-                                 OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
-                                 SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
-                                 SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
-                                 SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
-                                 RUN_BENCH_TARGET=run_orunchrt \
-                                 BUILD_BENCH_TARGET=multibench_parallel \
-                                 make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
-            fi
+            USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
+                RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
+                ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
+                OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \
+                OCAML_RUN_PARAM="`echo ${CONFIG_RUN_PARAMS}`" \
+                SANDMARK_CUSTOM_NAME="`echo ${CONFIG_NAME}`" \
+                SANDMARK_OVERRIDE_PACKAGES="`echo ${CONFIG_OVERRIDE_PACKAGES}`" \
+                SANDMARK_REMOVE_PACKAGES="`echo ${CONFIG_REMOVE_PACKAGES}`" \
+                RUN_BENCH_TARGET="`echo ${CONFIG_RUN_BENCH_TARGET}`" \
+                BUILD_BENCH_TARGET="`echo ${CONFIG_BUILD_BENCH_TARGET}`" \
+                make ocaml-versions/"${CONFIG_VARIANT}".bench > "${RESULTS_DIR}/${CONFIG_NAME}.${TIMESTAMP}.${COMMIT}.log" 2>&1
 
             # Copy results
             ls _results/*
@@ -164,11 +156,7 @@ while [ $i -lt ${COUNT} ]; do
         else
             echo "WARNING: ${TIMESTAMP}: Not running URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT} and EXPIRY=${CONFIG_EXPIRY}"
         fi
-        j=$((j+1))
     done
-
-    # Next custom variant
-    i=$((i+1))
 done
 
 # Cleanup


### PR DESCRIPTION
This add pausetimes benchmarking on sequential programs in the nightly navajo and turing runs.
It also refactors `run_all_custom.sh` to be a bit more readable.

Tested locally on Navajo