### PR TITLE
Use correct CPU when running benchmarks using current-bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,5 +409,8 @@ bash:
 %_filtered.json: %.json
 	jq '{wrappers : .wrappers, benchmarks: [.benchmarks | .[] | select(.tags | index($(TAG)) != null)]}' < $< > $@
 
+set-bench-cpu/%:
+	sed -i "s/cpu-list 5/cpu-list ${BENCH_CPU}/g" $*
+
 %_2domains.json: %.json
 	jq '{wrappers : .wrappers, benchmarks : [.benchmarks | .[] | {executable : .executable, name: .name, tags: .tags, runs : [.runs | .[] as $$item | if ($$item | .params | split(" ") | .[0] ) == "2" then $$item | .paramwrapper |= "" else empty end ] } ] }' < $< > $@

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,6 +1,9 @@
 FROM ocaml/opam:ubuntu-20.04-ocaml-4.12
 
-ENV BENCHCMD="TAG='\"run_in_ci\"' $(MAKE) run_config_filtered.json; USE_SYS_DUNE_HACK=1 OPT_WAIT=0 RUN_CONFIG_JSON=run_config_filtered.json $(MAKE) ocaml-versions/5.1.0+trunk.bench"
+ARG BENCH_CPU
+ENV BENCH_CPU=$BENCH_CPU
+
+ENV BENCHCMD="$(MAKE) set-bench-cpu/run_config.json; TAG='\"run_in_ci\"' $(MAKE) run_config_filtered.json; USE_SYS_DUNE_HACK=1 OPT_WAIT=0 RUN_CONFIG_JSON=run_config_filtered.json $(MAKE) ocaml-versions/5.1.0+trunk.bench"
 
 WORKDIR /app
 


### PR DESCRIPTION
The CPU is specified using a build arg and currently the configuration is specific to work only for sequential benchmarks. The production worker currently has only 2 isolated CPUs and it is not yet clear how we are going to run the parallel benchmarks using Autumn.