### PR TITLE
Remove gnuplot dependency for benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: 5.1.0+stable
         run: |
+          # TODO: Add gnuplot-x11 when irmin benchmarks are enabled
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
@@ -51,7 +52,7 @@ jobs:
 
       - name: 5.1.0+stable+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
           export ITER=1
@@ -67,7 +68,7 @@ jobs:
 
       - name: 5.1.0+trunk+serial
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
           export ITER=1
@@ -81,7 +82,7 @@ jobs:
 
       - name: 5.1.0+trunk+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
           export ITER=1
@@ -98,7 +99,7 @@ jobs:
 
       - name: test_notebooks
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip jo libgmp-dev
           python3 -m pip install markupsafe==2.0.1
           export PATH=$PATH:/home/opam/.local/bin
           pip3 install jupyter nbconvert seaborn pandas
@@ -135,7 +136,7 @@ jobs:
 
       - name: 5.0.0+trunk+serial
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
           export ITER=1
@@ -148,7 +149,7 @@ jobs:
 
       - name: 5.0.0+trunk+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo gnuplot-x11 libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
           eval $(opam env)
           export ITER=1

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -5,7 +5,8 @@ ENV BENCHCMD="TAG='\"run_in_ci\"' $(MAKE) run_config_filtered.json; USE_SYS_DUNE
 WORKDIR /app
 
 RUN sudo apt-get update
-RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf gnuplot libffi-dev cmake
+# TODO: Add gnuplot-x11 when irmin benchmarks are enabled
+RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf libffi-dev cmake libcap2-bin
 
 COPY . .
 


### PR DESCRIPTION
`gnuplot` was added as a dependecy as a part of the PR #343 since a library for running the Irmin benchmarks depended on it. But, we don't currently run the `irmin` benchmarks and the `gnuplot` dependency installs a whole bunch of X11 dependencies when setting up the OS for running the benchmarks. This makes the setup longer than it needs to be, as of now.