### PR TITLE
Fix regex for getting CONFIG_VARIANT from CONFIG_NAME

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -90,7 +90,7 @@ for i in $(seq 0 $((${COUNT} - 1))); do
         # Obtain configuration options
         CONFIG_URL=`jq -r '.['$i'].url' "${CUSTOM_FILE}"`
         CONFIG_NAME=`jq -r '.['$i'].name' "${CUSTOM_FILE}"`
-        CONFIG_VARIANT=$(grep -oP "(\\d|\.)+(\\+(trunk|stable))*" <<< "${CONFIG_NAME}")
+        CONFIG_VARIANT=$(grep -oP "^(\\d|\.)+(\\+(trunk|stable))*" <<< "${CONFIG_NAME}")
         CONFIG_EXPIRY=`jq -r '.['$i'].expiry // empty' "${CUSTOM_FILE}"`
         CONFIG_TAG=`jq -r '.['$i'].tag // "macro_bench"' "${CUSTOM_FILE}"`
         CONFIG_NAME="${CONFIG_NAME}+${KIND}"


### PR DESCRIPTION
The previous regex would parse a name like
`5.1.0+trunk+fabbing+prefetching_like_414` to `5.1.0+trunk\n414`.  This commit makes sure we only look at digits at the begnning of the config name.

*NOTE* The run_all_custom.sh script needs to be copied onto the bench machines.