### PR TITLE
Copy RUN_CONFIG_JSON file to results dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ ocaml-versions/%.bench: depend check-parallel/% filter/% override_packages/% log
 		$(PRE_BENCH_EXEC) $(ENVIRONMENT) opam exec --switch $(CONFIG_SWITCH_NAME) -- dune build -j 1 --profile=release				\
 		  --workspace=ocaml-versions/.workspace.$(CONFIG_SWITCH_NAME) @$(RUN_BENCH_TARGET); ex=$$?;						\
 		mkdir -p _results/;												\
+		cp ${RUN_CONFIG_JSON} _results/;										\
 		for i in `seq 1 $(ITER)`; do \
 			declare -A META=( ["arch"]="uname -m" ["hostname"]="hostname" ["kernel"]="uname -s" ["version"]="uname -r" ); \
 			s=""; for key in "$${!META[@]}"; do \


### PR DESCRIPTION
To keep track of the benchmarks that succeeded and failed, it would useful to have the RUN_CONFIG_JSON file with all the benchmark runs configuration. The results bench file can be compared against this to calculate the number of successful and failed benchmarks.

This PR is a complementary PR to https://github.com/ocaml-bench/sandmark-nightly/pull/117