### PR TITLE
Remove unnecessary double-dash in pausetimes command

### DIFF
--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes",
-      "command": "%{dep:pausetimes/pausetimes} %{output} -- %{paramwrapper} chrt -r 1 %{command}"
+      "command": "%{dep:pausetimes/pausetimes} %{output} %{paramwrapper} chrt -r 1 %{command}"
     }
   ],
   "benchmarks": [

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "pausetimes",
-      "command": "%{dep:pausetimes/pausetimes} %{output} -- %{paramwrapper} chrt -r 1 %{command}"
+      "command": "%{dep:pausetimes/pausetimes} %{output} %{paramwrapper} chrt -r 1 %{command}"
     }
   ],
 


### PR DESCRIPTION
When running the benchmarks via `opam exec -- dune build @${BUILD_BENCH_TARGET}` command, the additional `--` before the paramwrapper doesn't interact well with the pausetimes bash wrapper that evals an expression `eval "olly latency -o $TMP --json '$@'"`. Mysteriously, this eval fails with the error that `olly` executable couldn't be found when the additional `--` is present in the command. It is not entirely clear how this additional `--` affects the environment variables being set by opam exec, but this command removes them to get the benchmarks to run correctly.