### PR TITLE
Fix wget usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,16 +313,22 @@ check_jq:
 	};
 
 check_url: check_jq
-	@{ for f in `find ocaml-versions/*.json`; do					\
+	@{  if [ -z "$$(which wget)" ]; then							\
+		    echo "wget wasn't installed!";							\
+			exit 1;													\
+		fi;															\
+		for f in `find ocaml-versions/*.json`; do					\
 		HEAD=`head -1 $$f`;							\
 		if [ "$$HEAD" == "{" ]; then						\
 			URL=`jq -r '.url' $$f`;						\
 			if [ -z "$$URL" ] ; then					\
 				echo "No URL (mandatory) for $$f";			\
+				exit 1;												\
 			else								\
 				URL_EXISTS=`wget --spider $$URL 2>/dev/null; echo $$?`; \
 				if [ "$${URL_EXISTS}" != 0 ]; then			\
 					echo "Error: URL $$URL does not exist";		\
+					exit 1;											\
 				fi;							\
 			fi;								\
 		else									\
@@ -331,6 +337,7 @@ check_url: check_jq
 				URL_EXISTS=`wget --spider $$u 2>/dev/null; echo $$?`;	\
 				if [ "$${URL_EXISTS}" != 0 ]; then			\
 					echo "Error: URL $$u does not exist";		\
+					exit 1;											\
 				fi;							\
 			done;								\
 		fi;									\

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 RUN sudo apt-get update
 # TODO: Add gnuplot-x11 when irmin benchmarks are enabled
-RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf libffi-dev cmake libcap2-bin
+RUN sudo apt-get -y install libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf libffi-dev cmake libcap2-bin wget
 
 COPY . .
 


### PR DESCRIPTION
In my search to clean the Makefile, I discovered a bug:
We use `wget` to check for valid urls, but don't exit in case of failure. Adding the exits showcases that in some scenarios, `wget` might not be installed at all, which leads to printing "Error [URL] doesn't exist" even though it does exist, but the system didn't find wget.
The first commit of this PR fixes the printing and the exits, the second fixes the root bug and actually installs wget.