### PR TITLE
Run the run_all_custom.sh script wrapped in flock

### DIFF
--- a/nightly_navajo.sh
+++ b/nightly_navajo.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" bash /home/sandmark/production/run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/

--- a/nightly_turing.sh
+++ b/nightly_turing.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" bash /home/sandmark/production/run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/


### PR DESCRIPTION
The nightly cron jobs on Navajo have started to take almost a day, and sometimes this could lead to multiple benchmarks getting started at the same time. To prevent this we use the `flock` utility to detect if the process that previously owned a lock file is still alive, and not start another process if that's the case.

The call to `flock` is added to the nightly_* scripts so that it's more visible to the developers, rather than being hidden away in the crontab file.