### PR TITLE
Include MPL benchmarks in the nightly pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ onto CPU 5.
 The benchmarks also have associated tags which classify the benchmarks. The
 current tags are:
 
-* `macro_bench` - A macro benchmark.
+* `macro_bench` - A macro benchmark. Benchmarks with this tag are automatically
+    run nightly.
 * `run_in_ci` - This benchmark is run in the CI.
 * `lt_1s` - running time is less than 1s on the `turing` machine.
 * `1s_10s` - running time is between 1s and 10s on the `turing` machine.
@@ -283,6 +284,17 @@ You can add new benchmarks as follows:
     Add an entry for your benchmark run to the appropriate config file;
     `run_config.json` for sequential benchmarks and
     `multicore_parallel_run_config.json` for parallel benchmarks.
+
+    If you want the benchmark to be run nightly, make sure it has the
+    `macro_bench` tag. Additionally if you want to be able to correctly
+    visualize the results of the benchmark, it should follow a few conventions:
+    1. Its name should be `foo` for the serial version and `foo_multicore` for the
+       parallel version (a parallel version running on a single core is still
+       `_multicore`)
+    2. The first argument in `params` should be the number of domains, followed
+       possibly by other parameters. If that is not feasible, add a `short_name`
+       field with the format `<num_domains>_<other_arg>` with an `_` separating
+       the number of domains and other arguments.
 
 ### Config files
 

--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -20,51 +20,51 @@
   "benchmarks": [
     {
       "executable": "benchmarks/mpl/msort_ints.exe",
-      "name": "msort_ints",
-      "tags": ["gt_100s", "mpl"],
+      "name": "msort_ints_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_20000000",
           "params": "-procs 1 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_20000000",
           "params": "-procs 2 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-5"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_20000000",
           "params": "-procs 4 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-7"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_20000000",
           "params": "-procs 8 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-11"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_20000000",
           "params": "-procs 16 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-19"
         },
         {
-          "short_name": "32",
+          "short_name": "32_10_20000000",
           "params": "-procs 32 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-35"
         },
         {
-          "short_name": "64",
+          "short_name": "64_10_20000000",
           "params": "-procs 64 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-71"
         },
         {
-          "short_name": "96",
+          "short_name": "96_10_20000000",
           "params": "-procs 96 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-103"
         },
         {
-          "short_name": "120",
+          "short_name": "120_10_20000000",
           "params": "-procs 120 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-127"
         }
@@ -72,51 +72,51 @@
     },
     {
       "executable": "benchmarks/mpl/msort_strings.exe",
-      "name": "msort_strings",
-      "tags": ["gt_100s", "mpl"],
+      "name": "msort_strings_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_words64",
           "params": "-procs 1 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_words64",
           "params": "-procs 2 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-5"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_words64",
           "params": "-procs 4 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-7"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_words64",
           "params": "-procs 8 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-11"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_words64",
           "params": "-procs 16 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-19"
         },
         {
-          "short_name": "32",
+          "short_name": "32_10_words64",
           "params": "-procs 32 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-35"
         },
         {
-          "short_name": "64",
+          "short_name": "64_10_words64",
           "params": "-procs 64 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-63,68-71"
         },
         {
-          "short_name": "96",
+          "short_name": "96_10_words64",
           "params": "-procs 96 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-63,68-103"
         },
         {
-          "short_name": "120",
+          "short_name": "120_10_words64",
           "params": "-procs 120 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 4-63,68-127"
         }
@@ -124,51 +124,51 @@
     },
     {
       "executable": "benchmarks/mpl/primes.exe",
-      "name": "primes",
-      "tags": ["gt_100s", "mpl"],
+      "name": "primes_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_100000000",
           "params": "-procs 1 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_100000000",
           "params": "-procs 2 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-5"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_100000000",
           "params": "-procs 4 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-7"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_100000000",
           "params": "-procs 8 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-11"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_100000000",
           "params": "-procs 16 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-19"
         },
         {
-          "short_name": "32",
+          "short_name": "32_10_100000000",
           "params": "-procs 32 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-35"
         },
         {
-          "short_name": "64",
+          "short_name": "64_10_100000000",
           "params": "-procs 64 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-71"
         },
         {
-          "short_name": "96",
+          "short_name": "96_10_100000000",
           "params": "-procs 96 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-103"
         },
         {
-          "short_name": "120",
+          "short_name": "120_10_100000000",
           "params": "-procs 120 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 4-63,68-127"
         }
@@ -176,51 +176,51 @@
     },
     {
       "executable": "benchmarks/mpl/tokens.exe",
-      "name": "tokens",
-      "tags": ["gt_100s", "mpl"],
+      "name": "tokens_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_words64",
           "params": "-procs 1 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_words64",
           "params": "-procs 2 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-5"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_words64",
           "params": "-procs 4 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-7"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_words64",
           "params": "-procs 8 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-11"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_words64",
           "params": "-procs 16 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-19"
         },
         {
-          "short_name": "32",
+          "short_name": "32_10_words64",
           "params": "-procs 32 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-35"
         },
         {
-          "short_name": "64",
+          "short_name": "64_10_words64",
           "params": "-procs 64 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-63,68-71"
         },
         {
-          "short_name": "96",
+          "short_name": "96_10_words64",
           "params": "-procs 96 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-63,68-103"
         },
         {
-          "short_name": "120",
+          "short_name": "120_10_words64",
           "params": "-procs 120 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 4-63,68-127"
         }
@@ -228,51 +228,51 @@
     },
     {
       "executable": "benchmarks/mpl/raytracer.exe",
-      "name": "raytracer",
-      "tags": ["gt_100s", "mpl"],
+      "name": "raytracer_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_1000_1000",
           "params": "-procs 1 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_1000_1000",
           "params": "-procs 2 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-5"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_1000_1000",
           "params": "-procs 4 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-7"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_1000_1000",
           "params": "-procs 8 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-11"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_1000_1000",
           "params": "-procs 16 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-19"
         },
         {
-          "short_name": "32",
+          "short_name": "32_10_1000_1000",
           "params": "-procs 32 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-35"
         },
         {
-          "short_name": "64",
+          "short_name": "64_10_1000_1000",
           "params": "-procs 64 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-63,68-71"
         },
         {
-          "short_name": "96",
+          "short_name": "96_10_1000_1000",
           "params": "-procs 96 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-63,68-103"
         },
         {
-          "short_name": "120",
+          "short_name": "120_10_1000_1000",
           "params": "-procs 120 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 4-63,68-127"
         }

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -21,36 +21,36 @@
   "benchmarks": [
     {
       "executable": "benchmarks/mpl/msort_ints.exe",
-      "name": "msort_ints",
-      "tags": ["gt_100s", "mpl"],
+      "name": "msort_ints_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_20000000",
           "params": "-procs 1 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_20000000",
           "params": "-procs 2 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_20000000",
           "params": "-procs 4 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_20000000",
           "params": "-procs 8 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_20000000",
           "params": "-procs 16 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
-          "short_name": "24",
+          "short_name": "24_10_20000000",
           "params": "-procs 24 -repeat 10 -N 20000000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }
@@ -58,36 +58,36 @@
     },
     {
       "executable": "benchmarks/mpl/msort_strings.exe",
-      "name": "msort_strings",
-      "tags": ["gt_100s", "mpl"],
+      "name": "msort_strings_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_words64",
           "params": "-procs 1 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_words64",
           "params": "-procs 2 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_words64",
           "params": "-procs 4 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_words64",
           "params": "-procs 8 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_words64",
           "params": "-procs 16 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
-          "short_name": "24",
+          "short_name": "24_10_words64",
           "params": "-procs 24 -repeat 10 -f inputs/words64.txt",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }
@@ -95,36 +95,36 @@
     },
     {
       "executable": "benchmarks/mpl/primes.exe",
-      "name": "primes",
-      "tags": ["gt_100s", "mpl"],
+      "name": "primes_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_100000000",
           "params": "-procs 1 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_100000000",
           "params": "-procs 2 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_100000000",
           "params": "-procs 4 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_100000000",
           "params": "-procs 8 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_100000000",
           "params": "-procs 16 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
-          "short_name": "24",
+          "short_name": "24_10_100000000",
           "params": "-procs 24 -repeat 10 -N 100000000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }
@@ -132,36 +132,36 @@
     },
     {
       "executable": "benchmarks/mpl/tokens.exe",
-      "name": "tokens",
-      "tags": ["gt_100s", "mpl"],
+      "name": "tokens_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_words64",
           "params": "-procs 1 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_words64",
           "params": "-procs 2 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_words64",
           "params": "-procs 4 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_words64",
           "params": "-procs 8 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_words64",
           "params": "-procs 16 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
-          "short_name": "24",
+          "short_name": "24_10_words64",
           "params": "-procs 24 -repeat 10 -f inputs/words64.txt --no-output",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }
@@ -169,36 +169,36 @@
     },
     {
       "executable": "benchmarks/mpl/raytracer.exe",
-      "name": "raytracer",
-      "tags": ["gt_100s", "mpl"],
+      "name": "raytracer_multicore",
+      "tags": ["macro_bench", "gt_100s", "mpl"],
       "runs": [
         {
-          "short_name": "1",
+          "short_name": "1_10_1000_1000",
           "params": "-procs 1 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "2",
+          "short_name": "2_10_1000_1000",
           "params": "-procs 2 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "4",
+          "short_name": "4_10_1000_1000",
           "params": "-procs 4 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "8",
+          "short_name": "8_10_1000_1000",
           "params": "-procs 8 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13"
         },
         {
-          "short_name": "16",
+          "short_name": "16_10_1000_1000",
           "params": "-procs 16 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         },
         {
-          "short_name": "24",
+          "short_name": "24_10_1000_1000",
           "params": "-procs 24 -repeat 10 -n 1000 -m 1000",
           "paramwrapper": "taskset --cpu-list 2-13,16-27"
         }


### PR DESCRIPTION
Fix mpl benchmarks naming conventions and include it in the nightly runs. Additionally, document said conventions.

See https://github.com/ocaml-bench/sandmark/pull/404#issuecomment-1377033072