### PR TITLE
Minor improvements to the cron job logs

### DIFF
--- a/nightly_navajo.sh
+++ b/nightly_navajo.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_navajo.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh | ts '[%Y-%m-%d %H:%M:%S]'
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/

--- a/nightly_turing.sh
+++ b/nightly_turing.sh
@@ -25,7 +25,7 @@ check_sandmark_subdir $SANDMARK_NIGHTLY_DIR
 eval $(opam env)
 
 # Run!
-SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh
+SANDMARK_NIGHTLY_DIR=${SANDMARK_NIGHTLY_DIR} CUSTOM_FILE="https://raw.githubusercontent.com/ocaml-bench/sandmark-nightly-config/main/config/custom_turing.json" flock -w 7200 /tmp/sandmark.lock bash /home/sandmark/production/run_all_custom.sh | ts '[%Y-%m-%d %H:%M:%S]'
 
 # Push to sandmark-nightly
 cd $SANDMARK_NIGHTLY_DIR/sandmark-nightly/

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -135,7 +135,7 @@ for i in $(seq 0 $((${COUNT} - 1))); do
         COMMIT=$(find_commit ${CONFIG_URL})
         NOT_EXPIRED=$(check_not_expired ${CONFIG_EXPIRY})
 
-        echo "INFO: ${TIMESTAMP} Running benchmarks for URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON} for COMMIT=${COMMIT}"
+        echo "INFO: ${TIMESTAMP} Running benchmarks for URL=${CONFIG_URL}, CONFIG_TAG=${CONFIG_TAG}, CONFIG_RUN_JSON=${CONFIG_RUN_JSON}, KIND=${KIND} for COMMIT=${COMMIT}"
 
         if [[ ! -z "${COMMIT}" ]] && check_not_expired ${CONFIG_EXPIRY} && ! is_old_commit "${KIND}" "${HOSTNAME}" "${COMMIT}"; then
             # Create results directory


### PR DESCRIPTION
- Prepend timestamps to messages in the logs
- Print the "KIND" when printing INFO message before starting benchmarks

**NOTE**: The nightly scripts on `turing` and `navajo` would need to be updated after this merge to deploy the changes.

*EDIT*: I've made sure the `ts` utility is available on both the machines.