### PR TITLE
Basic tooling to validate multicore_*_run_config.json

### DIFF
--- a/.github/workflows/validate-multicore-config.yml
+++ b/.github/workflows/validate-multicore-config.yml
@@ -1,0 +1,22 @@
+---
+name: Validate Multicore Config
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'multicore_*_run_config.json'
+  push:
+    paths:
+      - 'multicore_*_run_config.json'
+
+jobs:
+  validate_multicore_config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run validation script
+        run: python validate_multicore_config.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing multicore benchmarks
+
+If you are contributing a parallel OCaml benchmark, ensure the following:
+
+1. The benchmark should have a serial version with the name `foo`.
+
+1. The benchmark should have a parallel version with the name `foo_multicore`.
+
+   **IMPORTANT**: Parallel version running on 1 domain is not the same as the
+   sequential version.
+
+1. The first argument (`params` or `short_name`) should be the number of
+   domains. There can be other arguments that follow. When using `short_name`,
+   the format should be `<num_domains>_<other_arg>` with an `_` separating the
+   number of domains and other arguments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,41 @@
-# Contributing multicore benchmarks
+# Adding Benchmarks
+
+You can add new benchmarks as follows:
+
+- **Add dependencies to packages:** If there are any package dependencies your
+  benchmark has that are not already included in Sandmark, add its opam file to
+  `dependencies/packages/<package-name>/<package-version>/opam`. If the package
+  depends on other packages, repeat this step for all of those packages. Add
+  the package to `PACKAGES` variable in the Makefile.
+
+- **Add benchmark files:** Find a relevant folder in `benchmarks/` and add your
+  code to it. Feel free to create a new folder if you don't find any existing
+  ones relevant. Every folder in `benchmarks/` has its own dune file; if you
+  are creating a new directory for your benchmark, also create a dune file in
+  that directory and add a stanza for your benchmark. If you are adding your
+  benchmark to an existing directory, add a dune stanza for your benchmark in
+  the directory's dune file.
+
+  Also add you code and input files if any to an alias,
+  `buildbench` for sequential benchmarks and `multibench_parallel` for
+  parallel benchmarks. For instance, if you are adding a parallel benchmark
+  `benchmark.ml` and its input file `input.txt` to a directory, in that
+  directory's dune file add
+
+  ```
+  (alias (name multibench_parallel) (deps benchmark.ml input.txt))
+  ```
+
+- **Add commands to run your applications:** Add an entry for your benchmark
+  run to the appropriate config file; `run_config.json` for sequential
+  benchmarks,`multicore_parallel_run_config.json` for parallel benchmarks run
+  on `turing` and `multicore_parallel_navajo_run_config.json` for parallel
+  benchmarks run on `navajo`.
+
+If you want the benchmark to be run nightly, make sure it has the `macro_bench`
+tag.
+
+## Conventions for multicore benchmarks
 
 If you are contributing a parallel OCaml benchmark, ensure the following:
 

--- a/README.md
+++ b/README.md
@@ -269,48 +269,7 @@ UI](https://sandmark.tarides.com/)
 
 ### Adding benchmarks
 
-You can add new benchmarks as follows:
-
- - **Add dependencies to packages:**
-    If there are any package dependencies your benchmark has that are not
-    already included in Sandmark, add its opam file to
-    `dependencies/packages/<package-name>/<package-version>/opam`. If the
-    package depends on other packages, repeat this step for all of those
-    packages. Add the package to `PACKAGES` variable in the Makefile.
-
- - **Add benchmark files:**
-    Find a relevant folder in `benchmarks/` and add your code to it. Feel free
-    to create a new folder if you don't find any existing ones relevant. Every
-    folder in `benchmarks/` has its own dune file; if you are creating a new
-    directory for your benchmark, also create a dune file in that directory and
-    add a stanza for your benchmark. If you are adding your benchmark to an
-    existing directory, add a dune stanza for your benchmark in the directory's
-    dune file.
-
-    Also add you code and input files if any to an alias,
-    `buildbench` for sequential benchmarks and `multibench_parallel` for
-    parallel benchmarks. For instance, if you are adding a parallel benchmark
-    `benchmark.ml` and its input file `input.txt` to a directory, in that
-    directory's dune file add
-    ```
-    (alias (name multibench_parallel) (deps benchmark.ml input.txt))
-    ```
-
- - **Add commands to run your applications:**
-    Add an entry for your benchmark run to the appropriate config file;
-    `run_config.json` for sequential benchmarks and
-    `multicore_parallel_run_config.json` for parallel benchmarks.
-
-    If you want the benchmark to be run nightly, make sure it has the
-    `macro_bench` tag. Additionally if you want to be able to correctly
-    visualize the results of the benchmark, it should follow a few conventions:
-    1. Its name should be `foo` for the serial version and `foo_multicore` for the
-       parallel version (a parallel version running on a single core is still
-       `_multicore`)
-    2. The first argument in `params` should be the number of domains, followed
-       possibly by other parameters. If that is not feasible, add a `short_name`
-       field with the format `<num_domains>_<other_arg>` with an `_` separating
-       the number of domains and other arguments.
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ### Config files
 

--- a/multicore_parallel_navajo_run_config.json
+++ b/multicore_parallel_navajo_run_config.json
@@ -21,7 +21,7 @@
     {
       "executable": "benchmarks/mpl/msort_ints.exe",
       "name": "msort_ints_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_20000000",
@@ -73,7 +73,7 @@
     {
       "executable": "benchmarks/mpl/msort_strings.exe",
       "name": "msort_strings_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_words64",
@@ -125,7 +125,7 @@
     {
       "executable": "benchmarks/mpl/primes.exe",
       "name": "primes_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_100000000",
@@ -177,7 +177,7 @@
     {
       "executable": "benchmarks/mpl/tokens.exe",
       "name": "tokens_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_words64",
@@ -229,7 +229,7 @@
     {
       "executable": "benchmarks/mpl/raytracer.exe",
       "name": "raytracer_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_1000_1000",
@@ -398,16 +398,48 @@
     {
       "executable": "benchmarks/graph500par/gen.exe",
       "name": "graph500_gen_multicore",
-      "tags": [ "macro_bench", "10s_100s" ],
+      "tags": ["macro_bench", "10s_100s"],
       "runs": [
-        { "params": "-ndomains 1 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 2 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 4 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 8 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 12 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 16 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 20 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 24 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+        {
+          "params": "-ndomains 1 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "1_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 2 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "2_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 4 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "4_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 8 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "8_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 12 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "12_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 16 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "16_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 20 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "20_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 24 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "24_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        }
       ]
     },
     {
@@ -421,16 +453,48 @@
     {
       "executable": "benchmarks/graph500par/kernel1_run_multicore.exe",
       "name": "graph500_kernel1_multicore",
-      "tags": [ "10s_100s", "macro_bench" ],
+      "tags": ["10s_100s", "macro_bench"],
       "runs": [
-        { "params": "-ndomains 1 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 2 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 4 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 8 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 12 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 20 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 24 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+        {
+          "params": "-ndomains 1 edges.data",
+          "short_name": "1_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 2 edges.data",
+          "short_name": "2_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 4 edges.data",
+          "short_name": "4_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 8 edges.data",
+          "short_name": "8_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 12 edges.data",
+          "short_name": "12_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 16 edges.data",
+          "short_name": "16_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 20 edges.data",
+          "short_name": "20_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 24 edges.data",
+          "short_name": "24_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        }
       ]
     },
     {

--- a/multicore_parallel_run_config.json
+++ b/multicore_parallel_run_config.json
@@ -22,7 +22,7 @@
     {
       "executable": "benchmarks/mpl/msort_ints.exe",
       "name": "msort_ints_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_20000000",
@@ -59,7 +59,7 @@
     {
       "executable": "benchmarks/mpl/msort_strings.exe",
       "name": "msort_strings_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_words64",
@@ -96,7 +96,7 @@
     {
       "executable": "benchmarks/mpl/primes.exe",
       "name": "primes_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_100000000",
@@ -133,7 +133,7 @@
     {
       "executable": "benchmarks/mpl/tokens.exe",
       "name": "tokens_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_words64",
@@ -170,7 +170,7 @@
     {
       "executable": "benchmarks/mpl/raytracer.exe",
       "name": "raytracer_multicore",
-      "tags": ["macro_bench", "gt_100s", "mpl"],
+      "tags": ["gt_100s", "mpl"],
       "runs": [
         {
           "short_name": "1_10_1000_1000",
@@ -305,16 +305,48 @@
     {
       "executable": "benchmarks/graph500par/gen.exe",
       "name": "graph500_gen_multicore",
-      "tags": [ "macro_bench", "10s_100s" ],
+      "tags": ["macro_bench", "10s_100s"],
       "runs": [
-        { "params": "-ndomains 1 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 2 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 4 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 8 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 12 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 16 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 20 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 24 -scale 21 -edgefactor 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+        {
+          "params": "-ndomains 1 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "1_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 2 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "2_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 4 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "4_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 8 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "8_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 12 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "12_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 16 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "16_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 20 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "20_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 24 -scale 21 -edgefactor 16 edges.data",
+          "short_name": "24_graph500_gen",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        }
       ]
     },
     {
@@ -328,16 +360,48 @@
     {
       "executable": "benchmarks/graph500par/kernel1_run_multicore.exe",
       "name": "graph500_kernel1_multicore",
-      "tags": [ "10s_100s", "macro_bench" ],
+      "tags": ["10s_100s", "macro_bench"],
       "runs": [
-        { "params": "-ndomains 1 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 2 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 4 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 8 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 12 edges.data", "paramwrapper": "taskset --cpu-list 2-13" },
-        { "params": "-ndomains 16 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 20 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" },
-        { "params": "-ndomains 24 edges.data", "paramwrapper": "taskset --cpu-list 2-13,16-27" }
+        {
+          "params": "-ndomains 1 edges.data",
+          "short_name": "1_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 2 edges.data",
+          "short_name": "2_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 4 edges.data",
+          "short_name": "4_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 8 edges.data",
+          "short_name": "8_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 12 edges.data",
+          "short_name": "12_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13"
+        },
+        {
+          "params": "-ndomains 16 edges.data",
+          "short_name": "16_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 20 edges.data",
+          "short_name": "20_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        },
+        {
+          "params": "-ndomains 24 edges.data",
+          "short_name": "24_graph500_kernel1",
+          "paramwrapper": "taskset --cpu-list 2-13,16-27"
+        }
       ]
     },
 

--- a/validate_multicore_config.py
+++ b/validate_multicore_config.py
@@ -1,0 +1,84 @@
+# Validation script to make it easier to contribute benchmarks to sandmark
+import json
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def validate_config(config_path, tag):
+    with open(config_path) as f:
+        config = json.load(f)
+
+    errors = []
+    benchmarks = [benchmark for benchmark in config["benchmarks"] if tag in benchmark["tags"]]
+    names = [benchmark["name"] for benchmark in benchmarks]
+    sequential_names = {name for name in names if not name.endswith("_multicore")}
+    multicore_names = {name for name in names if name.endswith("_multicore")}
+    multicore_names_no_suffix = {name[: -len("_multicore")] for name in multicore_names}
+
+    missing_sequential = multicore_names_no_suffix - sequential_names
+
+    if missing_sequential:
+        names = "\n    * ".join(sorted(f"{name}_multicore" for name in missing_sequential))
+        error = f"Sequential versions of these benchmarks are missing:\n    * {names}\n"
+        errors.append(error)
+
+    bench_map = {benchmark["name"]: benchmark for benchmark in benchmarks}
+
+    for name in multicore_names:
+        benchmark = bench_map[name]
+        for run in benchmark["runs"]:
+            if not (
+                run["params"].split()[0].isnumeric()
+                or run.get("short_name", "").split("_")[0].isnumeric()
+            ):
+                error = f"{name}: {run['params']} does not correctly specify the number of domains."
+                errors.append(error)
+
+    for name in sequential_names & multicore_names_no_suffix:
+        exec_seq = bench_map[name]["executable"]
+        exec_par = bench_map[f"{name}_multicore"]["executable"]
+        if exec_seq == exec_par:
+            error = f"{name}: Parallel version running on 1 domain is not the same as the sequential version."
+            errors.append(error)
+
+    if errors:
+        errors = "\n  ".join(errors)
+        print(f"Errors in '{config_path.name}' with '{tag}' tag:\n  {errors}")
+
+    skipped_benchmarks = {
+        benchmark["name"] for benchmark in config["benchmarks"] if tag not in benchmark["tags"]
+    }
+    if skipped_benchmarks:
+        names = "\n  ".join(skipped_benchmarks)
+        print(
+            f"WARNING: These benchmarks in '{config_path.name}' are not configured to run nightly:\n  {names}"
+        )
+
+    if errors or skipped_benchmarks:
+        print("#" * 80)
+
+    return not bool(errors)
+
+
+def main(tag):
+    configs = HERE.glob("multicore_*.json")
+    valid = True
+
+    for config in configs:
+        valid &= validate_config(config, tag=tag)
+
+    if not valid:
+        print("See CONTRIBUTING.md for more information on how to fix these errors.")
+        exit(1)
+    else:
+        print("All multicore configuration files are valid.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", type=str, default="macro_bench")
+    args = parser.parse_args()
+    main(tag=args.tag)


### PR DESCRIPTION
This PR adds some basic tooling to validate benchmarks configurations added to `multicore_*_run_config.json` files.  We also add a CONTRIBUTING.md file that gives some basic instructions on adding a parallel benchmark. 

The PR also modifies the existing JSON files to fix validation errors. This validation removes the benchmarks listed in #446 from the nightly runs. The run_config.json files need to be triaged separately to see why some of the benchmarks are skipped from nightly runs (don't have the `macro_bench` tag), and need to be fixed.