### PR TITLE
Print the JSON for each pausetimes benchmark in a single line

### DIFF
--- a/pausetimes/pausetimes
+++ b/pausetimes/pausetimes
@@ -5,5 +5,5 @@ OUTFILE=$1
 BENCH_NAME=$(basename $OUTFILE .pausetimes.bench)
 shift
 eval "olly latency -o $TMP --json '$@'"
-cat $TMP | jq "{name: \"$BENCH_NAME\"} + ." >"$OUTFILE"
+cat $TMP | jq -c "{name: \"$BENCH_NAME\"} + ." >"$OUTFILE"
 rm $TMP


### PR DESCRIPTION
For other kinds of benchmark measurements, the IPython notebooks and the nightly UI Python code assumes that each line in the benchmark file is valid JSON.  For consistency, it would help the pausetimes data formatted similarly.