### PR TITLE
Ensure configure options with spaces in them don't break builds

### DIFF
--- a/dependencies/template/ocaml-base-compiler/files/invoke-configure.sh
+++ b/dependencies/template/ocaml-base-compiler/files/invoke-configure.sh
@@ -1,16 +1,16 @@
 prefix="$1"
 os="$2"
 if [ -e configure.ac ]; then
-    exec ./configure ${OCAMLCONFIGOPTION} --prefix "$prefix" --with-default-string=unsafe
+    sh -c "exec ./configure ${OCAMLCONFIGOPTION} --prefix ${prefix} --with-default-string=unsafe"
 else
     unsafe_string=''
     if grep -q 'default_safe_string=true' configure; then
-	unsafe_string='-no-force-safe-string -default-unsafe-string'
+        unsafe_string='-no-force-safe-string -default-unsafe-string'
     fi
     case "$os" in
-	macos|freebsd|openbsd)
-	    exec ./configure ${OCAMLCONFIGOPTION} -prefix "$prefix" $unsafe_string -cc cc -aspp "cc -c";;
-	*)
-	    exec ./configure ${OCAMLCONFIGOPTION} -prefix "$prefix" $unsafe_string;;
+        macos|freebsd|openbsd)
+            sh -c "exec ./configure ${OCAMLCONFIGOPTION} -prefix $prefix $unsafe_string -cc cc -aspp \"cc -c\"";;
+        *)
+            sh -c "exec ./configure ${OCAMLCONFIGOPTION} -prefix $prefix $unsafe_string";;
     esac
 fi


### PR DESCRIPTION
Previously, `OCAMLCONFIGOPTION` set to something like `"CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'"` would break the builds because of the spaces in the environment variables. The build failed with the following error:

    configure: error: unrecognized option: `-Wa,-mbranches-within-32B''

For instance, see the build logs [here](https://github.com/ocaml-bench/sandmark-nightly/commit/1126df36c5d21bca87d95e1057d5fa3ef626b37b).

This commit ensures that spaces inside the single quoted strings are escaped correctly and the configure step runs correctly.