### PR TITLE
Add Owl GC regression test case.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev libopenblas-dev liblapacke-dev zlib1g-dev
           pip3 install intervaltree
 
       # Runs a set of commands using the runners shell
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev libopenblas-dev liblapacke-dev zlib1g-dev
           pip3 install intervaltree
 
       # Runs a set of commands using the runners shell
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev libopenblas-dev liblapacke-dev zlib1g-dev
           pip3 install intervaltree
 
       - name: 4.14.0+serial

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ else
 	PACKAGES += ctypes js_of_ocaml-compiler
 endif
 
-DEPENDENCIES = libgmp-dev libdw-dev jq jo python3-pip pkg-config m4 autoconf # Ubuntu
+DEPENDENCIES = libgmp-dev libdw-dev libopenblas-dev liblapacke-dev zlib1g-dev jq jo python3-pip pkg-config m4 autoconf # Ubuntu
 PIP_DEPENDENCIES = intervaltree
 
 .SECONDARY:

--- a/benchmarks/owl/dune
+++ b/benchmarks/owl/dune
@@ -1,0 +1,6 @@
+(executable
+ (name owl_gc)
+ (libraries owl unix)
+ (modes native))
+
+(alias (name buildbench) (deps owl_gc.exe))

--- a/benchmarks/owl/owl_gc.ml
+++ b/benchmarks/owl/owl_gc.ml
@@ -1,0 +1,104 @@
+module Gw = struct
+  open Bigarray
+  open Owl
+
+  type matrix =(float,  float64_elt, c_layout) Array2.t
+
+  type vector = (float,  float64_elt, c_layout) Array1.t
+
+  let uniform_dist n = let a = Array1.create Float64 C_layout n in
+    let () = Array1.fill a (1. /. Float.of_int n) in
+    a
+
+  let (@) x y = Mat.dot x y
+
+  let frobenius x y =
+    let t = (Owl_dense_ndarray_d.contract2 [| (0, 0); (1, 1) |] x y) in
+    Owl_dense_ndarray_d.get t [| |]
+
+  let c_a a_dmat a_pdist =
+    let a_dmat' = (genarray_of_array2 a_dmat) in
+    let a_pdist' = reshape (genarray_of_array1 a_pdist) [| (Array1.dim a_pdist) ; 1 |] in
+    frobenius ((Mat.mul a_dmat' a_dmat') @ a_pdist') a_pdist'
+
+  let gw_cost (a_dmat : matrix) (b_dmat : matrix)
+      (coupling : matrix) (c_A : float) (c_B : float) =
+    (* let frobenius x y = Mat.sum' (Mat.mul x y) in *)
+    let a_dmat' = (genarray_of_array2 a_dmat) in
+    let b_dmat' =(genarray_of_array2 b_dmat) in
+    let coupling' = (genarray_of_array2 coupling) in
+    c_A +. c_B -. (2. *. (frobenius (a_dmat' @ coupling' @ b_dmat') coupling'))
+
+  let cost_matrix a_dmat b_dmat coupling c_A c_B =
+    Mat.add_scalar (Mat.scalar_mul (-2.)
+                      (Mat.dot (Mat.dot (genarray_of_array2 a_dmat) (genarray_of_array2 coupling))
+                         (genarray_of_array2 b_dmat))) (c_A +. c_B)
+
+  let gw_new_coupling
+      (a_dmat : matrix)
+      (_a_pdist : vector)
+      (b_dmat : matrix)
+      (_b_pdist : vector)
+      (c_A : Mat.elt)
+      (c_B : Mat.elt)
+      (init_coupling : matrix)
+    =
+    let c = cost_matrix a_dmat b_dmat init_coupling c_A c_B in
+    array2_of_genarray c
+
+  let gw_init_coupling a_dmat a_pdist b_dmat b_pdist init_coupling =
+    let c_A = c_a a_dmat a_pdist in
+    let c_B = c_a b_dmat b_pdist in
+    let _init_cost = gw_cost a_dmat b_dmat init_coupling c_A c_B in
+    let rec _gw_init_coupling' current_coupling current_cost =
+      let coupling = gw_new_coupling a_dmat a_pdist b_dmat b_pdist c_A c_B current_coupling in
+      let new_cost = gw_cost a_dmat b_dmat coupling c_A c_B in
+      if new_cost <= 0. || new_cost >= current_cost then (current_cost, current_coupling)
+      else _gw_init_coupling' coupling new_cost
+    in
+    0., 0
+
+  let uniform_coupling (a_pdist : vector) (b_pdist : vector) =
+    let n = Array1.dim a_pdist in
+    let m = Array1.dim b_pdist in
+    let a_pdist' = reshape (genarray_of_array1 a_pdist) [| n; 1 |] in
+    let b_pdist' = reshape (genarray_of_array1 b_pdist) [| m; 1 |] in
+    array2_of_genarray (a_pdist' @ (Mat.transpose b_pdist'))
+
+  let gw_uniform a_dmat a_pdist b_dmat b_pdist  =
+    gw_init_coupling a_dmat a_pdist b_dmat b_pdist (uniform_coupling a_pdist b_pdist)
+end
+
+module Mat = Owl_dense_matrix_d
+
+let num_sample_pts = 100
+
+let dim = 100
+let () = Random.init 0
+let rand () =
+  let a = Bigarray.Array2.create Bigarray.Float64 Bigarray.C_layout dim dim in
+  for i = 0 to dim - 1 do
+    for j = 0 to dim -1 do
+      a.{i,j} <- Random.float 1.
+    done;
+  done;
+  a
+
+let icdms = Array.init num_sample_pts (fun _ -> rand ())
+
+let u = Gw.uniform_dist num_sample_pts
+
+let gw_by_index gw_dmat i j () =
+  let (a, _) = Gw.gw_uniform icdms.(i) u icdms.(j) u in
+  Bigarray.Genarray.set gw_dmat [|i; j|] a
+
+let n = Array.length icdms
+
+let gw_dmat = Mat.zeros n n
+
+let () =
+  for i=0 to n - 1 do
+    for j = i + 1 to n - 1 do
+      gw_by_index gw_dmat i j ()
+    done
+  done

--- a/dependencies/template/dev-4.14.0.opam
+++ b/dependencies/template/dev-4.14.0.opam
@@ -37,6 +37,8 @@ depends: [
   "ocaml-config" {= "1"}
   "ocamlgraph" {= "2.0.0"}
   "optint" {= "0.0.4"}
+  "owl" {= "1.1"}
+  "owl-base" {= "1.1"}
   "psmt2-frontend" {= "0.2"}
   "repr" {= "0.2.1"}
   "rresult" {= "0.6.0"}

--- a/dependencies/template/dev-5.x.opam
+++ b/dependencies/template/dev-5.x.opam
@@ -34,6 +34,8 @@ depends: [
   "num" {= "1.3"}
   "ocaml-config" {= "3"}
   "ocamlgraph" {= "2.0.0"}
+  "owl" {= "1.1"}
+  "owl-base" {= "1.1"}
   "psmt2-frontend" {= "0.4.0"}
   "repr" {= "0.6.0"}
   "rresult" {= "0.6.0"}

--- a/run_config.json
+++ b/run_config.json
@@ -1546,6 +1546,19 @@
           "params": "20"
         }
       ]
+    },
+    {
+      "executable": "benchmarks/owl/owl_gc.exe",
+      "name": "owl_gc",
+      "tags": [
+        "1s_10s",
+        "macro_bench"
+      ],
+      "runs": [
+        {
+          "params": ""
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Originally taken from
https://gitlab.inria.fr/fangelet/ocaml-gc-regression-examples and supplied by Florian Angeletti (@Octachron). This code was supplied on [Performance regression with multiple domains between 5.0 and 5.1](https://github.com/ocaml-bench/sandmark/compare/main...tmcgilchrist:owl_gc_regression?expand=1#top). 

This test will output timings to stdout of the form `4.14.1 | 2.395s |  1949 |   487 ` representing   `compiler version, time, minor GC, major GC`. How will that output be captured by sandmark or is there instrumentation already to capture this sort of GC information?
