### PR TITLE
Remove pins for sexplib0 and base libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,14 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
-      # Runs a set of commands using the runners shell
-      - name: 5.3.0+trunk+serial
+      - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
+
+      # Runs a set of commands using the runners shell
+      - name: 5.3.0+trunk+serial
+        run: |
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -51,8 +54,6 @@ jobs:
 
       - name: 5.3.0+trunk+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
-          pip3 install intervaltree
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -90,11 +91,14 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
-      # Runs a set of commands using the runners shell
-      - name: 5.2.0+trunk+serial
+      - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
           pip3 install intervaltree
+
+      # Runs a set of commands using the runners shell
+      - name: 5.2.0+trunk+serial
+        run: |
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -107,8 +111,6 @@ jobs:
 
       - name: 5.2.0+trunk+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
-          pip3 install intervaltree
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -143,10 +145,13 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo libgmp-dev
+          pip3 install intervaltree
+
       - name: 4.14.0+serial
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
-          pip3 install intervaltree
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true
@@ -158,8 +163,6 @@ jobs:
 
       - name: 4.14.0+parallel
         run: |
-          sudo apt-get update && sudo apt-get -y install wget pkg-config libgmp-dev m4 libdw-dev jq python3-pip autoconf jo
-          pip3 install intervaltree
           eval $(opam env)
           export ITER=1
           export OPAM_DISABLE_SANDBOXING=true

--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,6 @@ ifeq ($(OCAML_RUN_PARAM),)
 endif
 	opam update
 	OCAMLRUNPARAM="$(OCAML_RUN_PARAM)" OCAMLCONFIGOPTION="$(OCAML_CONFIG_OPTION)" opam switch create --keep-build-dir --yes $* ocaml-base-compiler.$*
-	@{ case "$*" in \
-		*5.*) opam pin add -n --yes --switch $* sexplib0.v0.15.0 https://github.com/shakthimaan/sexplib0.git#multicore;; \
-	esac };
 	# TODO remove pin when a new orun version is released on opam
 	opam pin add -n --yes --switch $* orun https://github.com/ocaml-bench/orun.git
 	# TODO remove pin when a new runtime_events_tools is released on opam

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,6 @@ endif
 	# TODO remove pin when a new runtime_events_tools is released on opam
 	opam pin add -n --yes --switch $* runtime_events_tools https://github.com/sadiqj/runtime_events_tools.git#09630b67b82f7d3226736793dd7bfc33999f4b25
 	opam pin add -n --yes --switch $* ocamlfind https://github.com/dra27/ocamlfind/archive/lib-layout.tar.gz
-	opam pin add -n --yes --switch $* base.v0.14.3 https://github.com/janestreet/base.git#v0.14.3
 	opam pin add -n --yes --switch $* coq-core https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
 	opam pin add -n --yes --switch $* coq-stdlib https://github.com/ejgallego/coq/archive/refs/tags/multicore-2021-09-29.tar.gz
 


### PR DESCRIPTION
They work with the latest versions of OCaml, and needn't be pinned to older versions or special branches/forks