### PR TITLE
Allow .zip archive URLs along with .tar.gz

### DIFF
--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -28,7 +28,7 @@ find_commit () {
         COMMIT=`git ls-remote https://github.com/ocaml/ocaml.git refs/heads/trunk | awk -F' ' '{print $1}'`
     elif [[ ${URL} == *"refs/head"* || ${URL} == *"refs/pull"* ]]; then
         GIT_SOURCE=`echo ${URL} | awk -F'/archive/' '{print $1}'`
-        REFS_PATH=`echo ${URL} | awk -F'/archive/' '{print $2}' | sed 's/.tar.gz//g'`
+        REFS_PATH=`echo ${URL} | awk -F'/archive/' '{print $2}' | sed 's/\(.tar.gz\|.zip\)//g'`
         COMMIT=`git ls-remote ${GIT_SOURCE} ${REFS_PATH} | awk -F' ' '{print $1}'`
     elif [[ ${URL} == *"archive"* ]]; then
         COMMIT=`echo ${URL##*/} | awk -F'.' '{print $1}'`


### PR DESCRIPTION
Closes ocaml/infrastructure#96

- [ ] The `run_all_custom.sh` scripts need to be updated on the bench machines, once the PR is merged. 