### PR TITLE
Revert "Use pinned dune instead of system dune"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           export OPAM_DISABLE_SANDBOXING=true
           TAG='"run_in_ci"' make run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' run_config_filtered.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.3.0+trunk.bench
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.3.0+trunk.bench
           ls _results
           cat _results/*
           make json
@@ -61,7 +61,7 @@ jobs:
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered_filtered.json
           make multicore_parallel_run_config_filtered_filtered_2domains.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.3.0+trunk.bench
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.3.0+trunk.bench
           ls _results
           cat _results/*
           make json
@@ -102,7 +102,7 @@ jobs:
           export OPAM_DISABLE_SANDBOXING=true
           TAG='"run_in_ci"' make run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' run_config_filtered.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.2.1+trunk.bench
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/5.2.1+trunk.bench
           ls _results
           cat _results/*
           make json
@@ -117,7 +117,7 @@ jobs:
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered_filtered.json
           make multicore_parallel_run_config_filtered_filtered_2domains.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.2.1+trunk.bench
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/5.2.1+trunk.bench
           ls _results
           cat _results/*
           make json
@@ -154,7 +154,7 @@ jobs:
           export OPAM_DISABLE_SANDBOXING=true
           TAG='"run_in_ci"' make run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' run_config_filtered.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.14.0.bench
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 RUN_CONFIG_JSON=run_config_filtered.json make ocaml-versions/4.14.0.bench
           ls _results
           cat _results/*
 
@@ -168,7 +168,7 @@ jobs:
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered.json
           sed -i 's/--cpu-list 5/--cpu-list 1/g' multicore_parallel_run_config_filtered_filtered.json
           make multicore_parallel_run_config_filtered_filtered_2domains.json
-          OPT_WAIT=0 USE_SYS_DUNE_HACK=0 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.14.0.bench || echo "Expected failure: Can't run parallel tests on 4.14.0"
+          OPT_WAIT=0 USE_SYS_DUNE_HACK=1 BUILD_BENCH_TARGET=multibench_parallel RUN_CONFIG_JSON=multicore_parallel_run_config_filtered_filtered_2domains.json make ocaml-versions/4.14.0.bench || echo "Expected failure: Can't run parallel tests on 4.14.0"
 
   test-notebooks:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -111,21 +111,6 @@ ifeq (1, $(USE_SYS_DUNE_HACK))
 	opam install --switch=$(CONFIG_SWITCH_NAME) --yes "dune.$(SANDMARK_DUNE_VERSION)" "dune-configurator.$(SANDMARK_DUNE_VERSION)"
 	# Pin the version so it doesn't change when installing packages
 	opam pin add --switch=$(CONFIG_SWITCH_NAME) --yes -n dune "$(SANDMARK_DUNE_VERSION)"
-else
-	@{ case "$*" in \
-		5.3.*) \
-			opam repo add upstream "git+https://github.com/ocaml/opam-repository.git" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2; \
-			opam install --switch=$(CONFIG_SWITCH_NAME) --yes ocamlfind; \
-			echo "Pinning dune to fixed version to work around binary and native compiler options split"; \
-			opam pin add --yes -n --switch=$(CONFIG_SWITCH_NAME) dune."$(SANDMARK_DUNE_VERSION)" https://github.com/ocaml-bench/dune.git#fix-compiler-opts; \
-			opam pin add --yes -n --switch=$(CONFIG_SWITCH_NAME) dune-configurator."$(SANDMARK_DUNE_VERSION)" https://github.com/ocaml-bench/dune.git#fix-compiler-opts; \
-			opam reinstall --switch=$(CONFIG_SWITCH_NAME) --yes dune dune-configurator ;; \
-		*) \
-			opam repo add upstream "git+https://github.com/ocaml/opam-repository.git" --on-switch=$(CONFIG_SWITCH_NAME) --rank 2; \
-			opam install --switch=$(CONFIG_SWITCH_NAME) --yes ocamlfind; \
-			opam install --switch=$(CONFIG_SWITCH_NAME) --yes "dune.$(SANDMARK_DUNE_VERSION)" "dune-configurator.$(SANDMARK_DUNE_VERSION)"; \
-			opam pin add --switch=$(CONFIG_SWITCH_NAME) --yes -n dune "$(SANDMARK_DUNE_VERSION)";; \
-	esac };
 endif
 
 ocamls=$(wildcard ocaml-versions/*.json)

--- a/run_all_custom.sh
+++ b/run_all_custom.sh
@@ -150,7 +150,7 @@ for i in $(seq 0 $((${COUNT} - 1))); do
             TAG=`echo "${TAG_STRING}"` make `echo ${CONFIG_RUN_JSON}`
 
             # Build and execute benchmarks
-            USE_SYS_DUNE_HACK=0 SANDMARK_URL="`echo ${CONFIG_URL}`" \
+            USE_SYS_DUNE_HACK=1 SANDMARK_URL="`echo ${CONFIG_URL}`" \
                 RUN_CONFIG_JSON="`echo ${CONFIG_RUN_JSON}`" \
                 ENVIRONMENT="`echo ${CONFIG_ENVIRONMENT}`" \
                 OCAML_CONFIG_OPTION="`echo ${CONFIG_OPTIONS}`" \

--- a/run_all_parallel.sh
+++ b/run_all_parallel.sh
@@ -8,7 +8,7 @@
 
 TAG='"macro_bench"' make multicore_parallel_run_config_filtered.json
 
-USE_SYS_DUNE_HACK=0 \
+USE_SYS_DUNE_HACK=1 \
                  RUN_BENCH_TARGET=run_orunchrt \
                  BUILD_BENCH_TARGET=multibench_parallel \
                  RUN_CONFIG_JSON=multicore_parallel_run_config_filtered.json \

--- a/run_all_serial.sh
+++ b/run_all_serial.sh
@@ -2,7 +2,7 @@
 
 TAG='"macro_bench"' make run_config_filtered.json
 
-OPT_WAIT=0 USE_SYS_DUNE_HACK=0 \
+OPT_WAIT=0 USE_SYS_DUNE_HACK=1 \
 	SANDMARK_CUSTOM_NAME=5.1.0+trunk \
 	RUN_CONFIG_JSON=run_config_filtered.json \
 	make ocaml-versions/5.1.0+trunk.bench


### PR DESCRIPTION
This reverts commits 19c98b1d8c7e3eba9b305cc318a139eab47faa66 and 7e5deb0063de2950fe56bec098cc0df08b433227. Upstream restored the variables that were removed in ocaml/ocaml#13201 in ocaml/ocaml#13244 for backward-compatibility.